### PR TITLE
chore: Removed folder `Dapr` reference

### DIFF
--- a/tests/NetEvolve.HealthChecks.Tests.Integration/NetEvolve.HealthChecks.Tests.Integration.csproj
+++ b/tests/NetEvolve.HealthChecks.Tests.Integration/NetEvolve.HealthChecks.Tests.Integration.csproj
@@ -63,9 +63,6 @@
     <ProjectReference Include="..\..\src\NetEvolve.HealthChecks\NetEvolve.HealthChecks.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <Folder Include="Dapr\" />
-  </ItemGroup>
-  <ItemGroup>
     <AssemblyAttribute Include="NetEvolve.Extensions.XUnit.SetCultureAttribute">
       <_Parameter1>en_US</_Parameter1>
       <_Parameter2>true</_Parameter2>


### PR DESCRIPTION
Because this folder has no content