### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/update-license.yml
+++ b/.github/workflows/update-license.yml
@@ -5,6 +5,10 @@ on:
     - cron: '0 6 1 1 *'
   workflow_dispatch:
 
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
   run:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/dailydevops/healthchecks/security/code-scanning/5](https://github.com/dailydevops/healthchecks/security/code-scanning/5)

To fix the issue, add a `permissions` block to the workflow to explicitly define the least privileges required for the task. Since the workflow involves reading repository contents, creating pull requests, and merging them, the permissions should be scoped to `contents: read` and `pull-requests: write`. This ensures that the `GITHUB_TOKEN` has only the necessary permissions to complete the task.

The `permissions` block should be added at the root level of the workflow file to apply to all jobs unless overridden. No additional dependencies or imports are required for this fix.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
