### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/cleanup-cache.yml
+++ b/.github/workflows/cleanup-cache.yml
@@ -1,5 +1,8 @@
 name: Delete Cache after PR merge
 
+permissions:
+  contents: read
+
 on:
   pull_request:
     types:


### PR DESCRIPTION
Potential fix for [https://github.com/dailydevops/healthchecks/security/code-scanning/3](https://github.com/dailydevops/healthchecks/security/code-scanning/3)

To fix the issue, we need to add a `permissions` block to the workflow. This block should specify the minimal permissions required for the workflow to function correctly. Based on the operations performed in the workflow (listing and deleting cache keys), the `contents: read` permission is sufficient for accessing repository contents, and no additional permissions are required.

The `permissions` block can be added at the root level of the workflow to apply to all jobs, or specifically to the `cleanup` job. In this case, adding it at the root level is preferable for simplicity, as there is only one job in the workflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
