### PR TITLE
revert: `Microsoft.AspNetCore.TestHost` to old version

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -58,7 +58,7 @@
     <PackageVersion Include="Microsoft.ApplicationInsights" Version="2.23.0" />
     <PackageVersion Include="Milvus.Client" Version="2.3.0-preview.1" />
     <PackageVersion Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.23.0" />
-    <PackageVersion Include="Microsoft.AspNetCore.TestHost" Version="10.0.0" />
+    <PackageVersion Include="Microsoft.AspNetCore.TestHost" Version="9.0.11" />
     <PackageVersion Include="Microsoft.CodeAnalysis.Analyzers" Version="3.11.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="4.14.0" />
     <PackageVersion Include="Microsoft.Data.SqlClient" Version="6.1.3" />

--- a/tests/NetEvolve.HealthChecks.Tests.Integration/NetEvolve.HealthChecks.Tests.Integration.csproj
+++ b/tests/NetEvolve.HealthChecks.Tests.Integration/NetEvolve.HealthChecks.Tests.Integration.csproj
@@ -56,6 +56,12 @@
     <PackageReference Include="System.Data.SqlClient" />
     <PackageReference Include="Testcontainers.PubSub" />
   </ItemGroup>
+  <ItemGroup Condition=" $(TargetFramework) == 'net8.0' ">
+    <PackageReference Include="Microsoft.AspNetCore.TestHost" VersionOverride="8.0.22" />
+  </ItemGroup>
+  <ItemGroup Condition=" $(TargetFramework) == 'net9.0' ">
+    <PackageReference Include="Microsoft.AspNetCore.TestHost" VersionOverride="9.0.11" />
+  </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Azure.Identity" />
     <PackageReference Include="CliWrap" />
@@ -65,12 +71,6 @@
     </PackageReference>
     <PackageReference Include="coverlet.msbuild" />
     <PackageReference Include="DuckDB.NET.Bindings.Full" />
-    <PackageReference
-      Include="Microsoft.AspNetCore.TestHost"
-      Condition=" $(TargetFramework) == 'net8.0' "
-      VersionOverride="10.0.0"
-    />
-    <PackageReference Include="Microsoft.AspNetCore.TestHost" Condition=" $(TargetFramework) != 'net8.0' " />
     <PackageReference Include="Microsoft.Extensions.Azure" />
     <PackageReference Include="Microsoft.Testing.Extensions.CodeCoverage" />
     <PackageReference Include="NetEvolve.Extensions.TUnit" />


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated test infrastructure dependencies with version adjustments and framework-specific configurations to ensure compatibility across different .NET target frameworks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->