### PR TITLE
fix(ci): Repaired Coverage Step to get coverage report

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -106,10 +106,14 @@ jobs:
     name: Collect Code Coverage
     needs:
       - tests
+      - version
     uses: ./.github/workflows/step-coverage.yml
     with:
+      dotnet-logging: ${{ inputs.dotnet-logging || 'minimal' }}
+      dotnet-version: ${{ vars.NE_DOTNET_TARGETFRAMEWORKS }}
       runs-on: 'ubuntu-latest'
       solution: ./HealthChecks.slnx
+      solution-version: ${{ needs.version.outputs.solution-version }}
     secrets: inherit
 
   build:

--- a/.github/workflows/step-coverage.yml
+++ b/.github/workflows/step-coverage.yml
@@ -1,11 +1,22 @@
 on:
   workflow_call:
     inputs:
+      dotnet-version:
+        required: false
+        type: string
+        default: '10.0.x'
+      dotnet-logging:
+        required: false
+        type: string
+        default: minimal
       runs-on:
         required: false
         type: string
         default: ubuntu-latest
       solution:
+        required: true
+        type: string
+      solution-version:
         required: true
         type: string
     secrets:
@@ -30,15 +41,23 @@ jobs:
         submodules: recursive
         token: ${{ github.token }}
 
+    - name: Setup .NET
+      uses: actions/setup-dotnet@v5.0.0
+      with:
+        dotnet-version: ${{ inputs.dotnet-version }}
+        global-json-file: ./global.json
+
+    - name: Restore dependencies
+      run: dotnet restore ${{ inputs.solution }} -v ${{ inputs.dotnet-logging }}
+
+    - name: Build
+      run: dotnet build ${{ inputs.solution }} -v ${{ inputs.dotnet-logging }} -c Release --no-restore /p:Version=${{ inputs.solution-version }}
+
     - name: Download Build files
       uses: actions/download-artifact@v6.0.0
       with:
         pattern: coverage-*
         merge-multiple: true
-
-    - name: List all Files
-      run: |
-        ls -r ${{ github.workspace }}
 
     - name: ReportGenerator
       uses: danielpalme/ReportGenerator-GitHub-Action@5.5.0


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI workflow updated to support explicit .NET tooling and solution version inputs, ensure repository checkout depth/submodule access, and run restore/build with versioning.
  * Test and coverage jobs now depend on the versioning step so artifacts and coverage align with the built version.
  * Removed a redundant repository file-listing step; artifact download and reporting remain unchanged.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->