### PR TITLE
fix: Adjust directory handling in Collect-TestProjects.ps1

### DIFF
--- a/.github/scripts/Collect-TestProjects.ps1
+++ b/.github/scripts/Collect-TestProjects.ps1
@@ -8,6 +8,10 @@
     throws an error if missing, and outputs filtered projects as compressed JSON.
 #>
 
+# Set Location to Parents parent directory
+$currentDirectory = Get-Location
+Set-Location (Split-Path (Split-Path (Split-Path $MyInvocation.MyCommand.Definition -Parent) -Parent) -Parent)
+
 # Get all testgroups from the test projects
 $testGroups = Get-ChildItem -Path "tests/NetEvolve.HealthChecks.Tests.Integration" -Recurse -Filter "*.csproj" | ForEach-Object {
   $projectDir = $_.Directory.FullName
@@ -40,6 +44,8 @@ $testGroups = Get-ChildItem -Path "tests/NetEvolve.HealthChecks.Tests.Integratio
   }
 }
 
+# Revert to $currenctDirectory
+Set-Location $currentDirectory
 # Convert the collected testgroups to compressed JSON format
 $testGroupsJson = $testGroups | Sort-Object -Unique | ConvertTo-Json -AsArray -Compress
 $testGroupsJson ?? "[]"


### PR DESCRIPTION
Added logic to change directory to the parent directory before scanning test projects and revert back after completion.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated test collection script to modify the working directory context during execution and restore it afterward. Core test collection logic remains unchanged.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->