### PR TITLE
fix: Validate attribute constructor argument counts

### DIFF
--- a/src/SourceGenerator.HealthChecks/Generators/ConfigurableHealthCheckGenerator.cs
+++ b/src/SourceGenerator.HealthChecks/Generators/ConfigurableHealthCheckGenerator.cs
@@ -81,6 +81,11 @@ internal sealed class ConfigurableHealthCheckGenerator : IIncrementalGenerator
         AttributeData attributeData
     )
     {
+        if (attributeData.ConstructorArguments.Length != 2)
+        {
+            return null;
+        }
+
         if (attributeData.ConstructorArguments[0].Value is not ISymbol optionsType)
         {
             return null;

--- a/src/SourceGenerator.HealthChecks/Generators/SqlHealthCheckGenerator.cs
+++ b/src/SourceGenerator.HealthChecks/Generators/SqlHealthCheckGenerator.cs
@@ -124,6 +124,11 @@ internal sealed class SqlHealthCheckGenerator : IIncrementalGenerator
         AttributeData attributeData
     )
     {
+        if (attributeData.ConstructorArguments.Length != 3)
+        {
+            return null;
+        }
+
         if (attributeData.ConstructorArguments[0].Value is not ISymbol connectionType)
         {
             return null;


### PR DESCRIPTION
Add checks to ensure attributeData has the expected number of constructor arguments in both ConfigurableHealthCheckGenerator (2 arguments) and SqlHealthCheckGenerator (3 arguments). Return null early if the count does not match to prevent potential errors from invalid attribute usage.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced validation for health check configuration to prevent runtime errors and ensure components are initialized with proper parameters.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->