### PR TITLE
chore: Move tests from Z05TestGroup to Z04TestGroup

### DIFF
--- a/tests/NetEvolve.HealthChecks.Tests.Integration/Azure.Kusto/.testgroup
+++ b/tests/NetEvolve.HealthChecks.Tests.Integration/Azure.Kusto/.testgroup
@@ -1,1 +1,1 @@
-Z05TestGroup
+Z04TestGroup

--- a/tests/NetEvolve.HealthChecks.Tests.Integration/Azure.Kusto/KustoAvailableHealthCheckTests.cs
+++ b/tests/NetEvolve.HealthChecks.Tests.Integration/Azure.Kusto/KustoAvailableHealthCheckTests.cs
@@ -7,7 +7,7 @@ using NetEvolve.Extensions.TUnit;
 using NetEvolve.HealthChecks.Azure.Kusto;
 
 [TestGroup($"{nameof(Azure)}.{nameof(Kusto)}")]
-[TestGroup("Z05TestGroup")]
+[TestGroup("Z04TestGroup")]
 [ClassDataSource<KustoAccess>(Shared = SharedType.PerClass)]
 public class KustoAvailableHealthCheckTests : HealthCheckTestBase
 {

--- a/tests/NetEvolve.HealthChecks.Tests.Integration/Cassandra/.testgroup
+++ b/tests/NetEvolve.HealthChecks.Tests.Integration/Cassandra/.testgroup
@@ -1,1 +1,1 @@
-Z05TestGroup
+Z04TestGroup

--- a/tests/NetEvolve.HealthChecks.Tests.Integration/Cassandra/CassandraHealthCheckTests.cs
+++ b/tests/NetEvolve.HealthChecks.Tests.Integration/Cassandra/CassandraHealthCheckTests.cs
@@ -12,7 +12,7 @@ using NetEvolve.HealthChecks.Cassandra;
 
 [ClassDataSource<CassandraDatabase>(Shared = SharedType.PerClass)]
 [TestGroup(nameof(Cassandra))]
-[TestGroup("Z05TestGroup")]
+[TestGroup("Z04TestGroup")]
 public class CassandraHealthCheckTests : HealthCheckTestBase, IAsyncInitializer, IDisposable
 {
     private readonly CassandraDatabase _database;

--- a/tests/NetEvolve.HealthChecks.Tests.Integration/GCP.BigQuery/.testgroup
+++ b/tests/NetEvolve.HealthChecks.Tests.Integration/GCP.BigQuery/.testgroup
@@ -1,1 +1,1 @@
-Z05TestGroup
+Z04TestGroup

--- a/tests/NetEvolve.HealthChecks.Tests.Integration/GCP.BigQuery/BigQueryHealthCheckTests.cs
+++ b/tests/NetEvolve.HealthChecks.Tests.Integration/GCP.BigQuery/BigQueryHealthCheckTests.cs
@@ -12,7 +12,7 @@ using NetEvolve.Extensions.TUnit;
 using NetEvolve.HealthChecks.GCP.BigQuery;
 
 [TestGroup($"GCP.{nameof(BigQuery)}")]
-[TestGroup("Z05TestGroup")]
+[TestGroup("Z04TestGroup")]
 [ClassDataSource<BigQueryDatabase>(Shared = SharedType.PerClass)]
 public sealed class BigQueryHealthCheckTests : HealthCheckTestBase
 {

--- a/tests/NetEvolve.HealthChecks.Tests.Integration/GCP.Bigtable/.testgroup
+++ b/tests/NetEvolve.HealthChecks.Tests.Integration/GCP.Bigtable/.testgroup
@@ -1,1 +1,1 @@
-Z05TestGroup
+Z04TestGroup

--- a/tests/NetEvolve.HealthChecks.Tests.Integration/GCP.Bigtable/BigtableHealthCheckTests.cs
+++ b/tests/NetEvolve.HealthChecks.Tests.Integration/GCP.Bigtable/BigtableHealthCheckTests.cs
@@ -10,7 +10,7 @@ using NetEvolve.Extensions.TUnit;
 using NetEvolve.HealthChecks.GCP.Bigtable;
 
 [TestGroup($"GCP.{nameof(Bigtable)}")]
-[TestGroup("Z05TestGroup")]
+[TestGroup("Z04TestGroup")]
 [ClassDataSource<BigtableDatabase>(Shared = SharedType.PerClass)]
 public sealed class BigtableHealthCheckTests : HealthCheckTestBase
 {

--- a/tests/NetEvolve.HealthChecks.Tests.Integration/Mosquitto/.testgroup
+++ b/tests/NetEvolve.HealthChecks.Tests.Integration/Mosquitto/.testgroup
@@ -1,1 +1,1 @@
-Z05TestGroup
+Z04TestGroup

--- a/tests/NetEvolve.HealthChecks.Tests.Integration/Mosquitto/MosquittoHealthCheckTests.cs
+++ b/tests/NetEvolve.HealthChecks.Tests.Integration/Mosquitto/MosquittoHealthCheckTests.cs
@@ -11,7 +11,7 @@ using NetEvolve.HealthChecks.Mosquitto;
 
 [ClassDataSource<MosquittoContainer>]
 [TestGroup(nameof(Mosquitto))]
-[TestGroup("Z05TestGroup")]
+[TestGroup("Z04TestGroup")]
 public sealed class MosquittoHealthCheckTests : HealthCheckTestBase
 {
     private readonly MosquittoContainer _container;

--- a/tests/NetEvolve.HealthChecks.Tests.Integration/Neo4j/.testgroup
+++ b/tests/NetEvolve.HealthChecks.Tests.Integration/Neo4j/.testgroup
@@ -1,1 +1,1 @@
-Z05TestGroup
+Z04TestGroup

--- a/tests/NetEvolve.HealthChecks.Tests.Integration/Neo4j/Neo4jHealthCheckTests.cs
+++ b/tests/NetEvolve.HealthChecks.Tests.Integration/Neo4j/Neo4jHealthCheckTests.cs
@@ -12,7 +12,7 @@ using NetEvolve.HealthChecks.Neo4j;
 
 [ClassDataSource<Neo4jDatabase>(Shared = SharedType.PerClass)]
 [TestGroup(nameof(Neo4j))]
-[TestGroup("Z05TestGroup")]
+[TestGroup("Z04TestGroup")]
 public class Neo4jHealthCheckTests : HealthCheckTestBase, IAsyncInitializer, IDisposable
 {
     private readonly Neo4jDatabase _database;


### PR DESCRIPTION
Updated the [TestGroup] annotation from "Z05TestGroup" to "Z04TestGroup" in several test files, including KustoAvailableHealthCheckTests.cs, CassandraHealthCheckTests.cs, BigQueryHealthCheckTests.cs, BigtableHealthCheckTests.cs, MosquittoHealthCheckTests.cs, and Neo4jHealthCheckTests.cs. Also updated the .testgroup file to reflect this change, effectively reassigning these tests to the new group.