### PR TITLE
chore: Replace custom argument checks with .NET ArgumentException

### DIFF
--- a/src/NetEvolve.HealthChecks.Elasticsearch/ElasticsearchConfigure.cs
+++ b/src/NetEvolve.HealthChecks.Elasticsearch/ElasticsearchConfigure.cs
@@ -6,7 +6,6 @@ using Elastic.Clients.Elasticsearch;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
-using NetEvolve.Arguments;
 using static Microsoft.Extensions.Options.ValidateOptionsResult;
 
 internal sealed class ElasticsearchConfigure
@@ -30,7 +29,7 @@ internal sealed class ElasticsearchConfigure
     /// <inheritdoc />
     public void Configure(string? name, ElasticsearchOptions options)
     {
-        Argument.ThrowIfNullOrWhiteSpace(name);
+        ArgumentException.ThrowIfNullOrWhiteSpace(name);
         _configuration.Bind($"HealthChecks:Elasticsearch:{name}", options);
     }
 

--- a/src/NetEvolve.HealthChecks.MySql.Devart/DependencyInjectionExtensions.cs
+++ b/src/NetEvolve.HealthChecks.MySql.Devart/DependencyInjectionExtensions.cs
@@ -6,7 +6,6 @@ using System.Linq;
 using global::Devart.Data.MySql;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
-using NetEvolve.Arguments;
 using SourceGenerator.Attributes;
 
 /// <summary>
@@ -37,7 +36,7 @@ public static partial class DependencyInjectionExtensions
     )
     {
         ArgumentNullException.ThrowIfNull(builder);
-        Argument.ThrowIfNullOrEmpty(name);
+        ArgumentException.ThrowIfNullOrEmpty(name);
         ArgumentNullException.ThrowIfNull(tags);
 
         if (!builder.IsServiceTypeRegistered<MySqlDevartCheckMarker>())

--- a/src/NetEvolve.HealthChecks.MySql.Devart/MySqlDevartConfigure.cs
+++ b/src/NetEvolve.HealthChecks.MySql.Devart/MySqlDevartConfigure.cs
@@ -3,7 +3,6 @@ namespace NetEvolve.HealthChecks.MySql.Devart;
 using System.Threading;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Options;
-using NetEvolve.Arguments;
 using static Microsoft.Extensions.Options.ValidateOptionsResult;
 
 internal sealed class MySqlDevartConfigure
@@ -17,7 +16,7 @@ internal sealed class MySqlDevartConfigure
 
     public void Configure(string? name, MySqlDevartOptions options)
     {
-        Argument.ThrowIfNullOrWhiteSpace(name);
+        ArgumentException.ThrowIfNullOrWhiteSpace(name);
         _configuration.Bind($"HealthChecks:MySql:{name}", options);
     }
 

--- a/src/NetEvolve.HealthChecks.Npgsql.Devart/DependencyInjectionExtensions.cs
+++ b/src/NetEvolve.HealthChecks.Npgsql.Devart/DependencyInjectionExtensions.cs
@@ -6,7 +6,6 @@ using System.Linq;
 using global::Devart.Data.PostgreSql;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
-using NetEvolve.Arguments;
 using SourceGenerator.Attributes;
 
 /// <summary>
@@ -37,7 +36,7 @@ public static partial class DependencyInjectionExtensions
     )
     {
         ArgumentNullException.ThrowIfNull(builder);
-        Argument.ThrowIfNullOrEmpty(name);
+        ArgumentException.ThrowIfNullOrEmpty(name);
         ArgumentNullException.ThrowIfNull(tags);
 
         if (!builder.IsServiceTypeRegistered<NpgsqlDevartCheckMarker>())

--- a/src/NetEvolve.HealthChecks.Npgsql.Devart/NpgsqlDevartConfigure.cs
+++ b/src/NetEvolve.HealthChecks.Npgsql.Devart/NpgsqlDevartConfigure.cs
@@ -3,7 +3,6 @@ namespace NetEvolve.HealthChecks.Npgsql.Devart;
 using System.Threading;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Options;
-using NetEvolve.Arguments;
 using static Microsoft.Extensions.Options.ValidateOptionsResult;
 
 internal sealed class NpgsqlDevartConfigure
@@ -17,7 +16,7 @@ internal sealed class NpgsqlDevartConfigure
 
     public void Configure(string? name, NpgsqlDevartOptions options)
     {
-        Argument.ThrowIfNullOrWhiteSpace(name);
+        ArgumentException.ThrowIfNullOrWhiteSpace(name);
         _configuration.Bind($"HealthChecks:Npgsql:{name}", options);
     }
 

--- a/src/NetEvolve.HealthChecks.OpenSearch/OpenSearchConfigure.cs
+++ b/src/NetEvolve.HealthChecks.OpenSearch/OpenSearchConfigure.cs
@@ -6,7 +6,6 @@ using global::OpenSearch.Client;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
-using NetEvolve.Arguments;
 using static Microsoft.Extensions.Options.ValidateOptionsResult;
 
 internal sealed class OpenSearchConfigure
@@ -30,7 +29,7 @@ internal sealed class OpenSearchConfigure
     /// <inheritdoc />
     public void Configure(string? name, OpenSearchOptions options)
     {
-        Argument.ThrowIfNullOrWhiteSpace(name);
+        ArgumentException.ThrowIfNullOrWhiteSpace(name);
         _configuration.Bind($"HealthChecks:OpenSearch:{name}", options);
     }
 

--- a/src/NetEvolve.HealthChecks.Oracle.Devart/DependencyInjectionExtensions.cs
+++ b/src/NetEvolve.HealthChecks.Oracle.Devart/DependencyInjectionExtensions.cs
@@ -6,7 +6,6 @@ using System.Linq;
 using global::Devart.Data.Oracle;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
-using NetEvolve.Arguments;
 using SourceGenerator.Attributes;
 
 /// <summary>
@@ -37,7 +36,7 @@ public static partial class DependencyInjectionExtensions
     )
     {
         ArgumentNullException.ThrowIfNull(builder);
-        Argument.ThrowIfNullOrEmpty(name);
+        ArgumentException.ThrowIfNullOrEmpty(name);
         ArgumentNullException.ThrowIfNull(tags);
 
         if (!builder.IsServiceTypeRegistered<OracleDevartCheckMarker>())

--- a/src/NetEvolve.HealthChecks.Oracle.Devart/OracleDevartConfigure.cs
+++ b/src/NetEvolve.HealthChecks.Oracle.Devart/OracleDevartConfigure.cs
@@ -3,7 +3,6 @@ namespace NetEvolve.HealthChecks.Oracle.Devart;
 using System.Threading;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Options;
-using NetEvolve.Arguments;
 using static Microsoft.Extensions.Options.ValidateOptionsResult;
 
 internal sealed class OracleDevartConfigure
@@ -17,7 +16,7 @@ internal sealed class OracleDevartConfigure
 
     public void Configure(string? name, OracleDevartOptions options)
     {
-        Argument.ThrowIfNullOrWhiteSpace(name);
+        ArgumentException.ThrowIfNullOrWhiteSpace(name);
         _configuration.Bind($"HealthChecks:Oracle:{name}", options);
     }
 

--- a/src/NetEvolve.HealthChecks.SQLite.Devart/DependencyInjectionExtensions.cs
+++ b/src/NetEvolve.HealthChecks.SQLite.Devart/DependencyInjectionExtensions.cs
@@ -6,7 +6,6 @@ using System.Linq;
 using global::Devart.Data.SQLite;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
-using NetEvolve.Arguments;
 using SourceGenerator.Attributes;
 
 /// <summary>
@@ -37,7 +36,7 @@ public static partial class DependencyInjectionExtensions
     )
     {
         ArgumentNullException.ThrowIfNull(builder);
-        Argument.ThrowIfNullOrEmpty(name);
+        ArgumentException.ThrowIfNullOrEmpty(name);
         ArgumentNullException.ThrowIfNull(tags);
 
         if (!builder.IsServiceTypeRegistered<SQLiteDevartCheckMarker>())

--- a/src/NetEvolve.HealthChecks.SQLite.Devart/SQLiteDevartConfigure.cs
+++ b/src/NetEvolve.HealthChecks.SQLite.Devart/SQLiteDevartConfigure.cs
@@ -3,7 +3,6 @@ namespace NetEvolve.HealthChecks.SQLite.Devart;
 using System.Threading;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Options;
-using NetEvolve.Arguments;
 using static Microsoft.Extensions.Options.ValidateOptionsResult;
 
 internal sealed class SQLiteDevartConfigure
@@ -17,7 +16,7 @@ internal sealed class SQLiteDevartConfigure
 
     public void Configure(string? name, SQLiteDevartOptions options)
     {
-        Argument.ThrowIfNullOrWhiteSpace(name);
+        ArgumentException.ThrowIfNullOrWhiteSpace(name);
         _configuration.Bind($"HealthChecks:SQLite:{name}", options);
     }
 

--- a/src/NetEvolve.HealthChecks.SqlServer.Devart/DependencyInjectionExtensions.cs
+++ b/src/NetEvolve.HealthChecks.SqlServer.Devart/DependencyInjectionExtensions.cs
@@ -6,7 +6,6 @@ using System.Linq;
 using global::Devart.Data.SqlServer;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
-using NetEvolve.Arguments;
 using SourceGenerator.Attributes;
 
 /// <summary>
@@ -37,7 +36,7 @@ public static partial class DependencyInjectionExtensions
     )
     {
         ArgumentNullException.ThrowIfNull(builder);
-        Argument.ThrowIfNullOrEmpty(name);
+        ArgumentException.ThrowIfNullOrEmpty(name);
         ArgumentNullException.ThrowIfNull(tags);
 
         if (!builder.IsServiceTypeRegistered<SqlServerDevartCheckMarker>())

--- a/src/NetEvolve.HealthChecks.SqlServer.Devart/SqlServerDevartConfigure.cs
+++ b/src/NetEvolve.HealthChecks.SqlServer.Devart/SqlServerDevartConfigure.cs
@@ -3,7 +3,6 @@
 using System.Threading;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Options;
-using NetEvolve.Arguments;
 using static Microsoft.Extensions.Options.ValidateOptionsResult;
 
 internal sealed class SqlServerDevartConfigure
@@ -17,7 +16,7 @@ internal sealed class SqlServerDevartConfigure
 
     public void Configure(string? name, SqlServerDevartOptions options)
     {
-        Argument.ThrowIfNullOrWhiteSpace(name);
+        ArgumentException.ThrowIfNullOrWhiteSpace(name);
         _configuration.Bind($"HealthChecks:SqlServer:{name}", options);
     }
 


### PR DESCRIPTION
Removed usage of NetEvolve.Arguments.Argument in favor of built-in ArgumentException.ThrowIfNullOrWhiteSpace and ArgumentException.ThrowIfNullOrEmpty for argument validation. Updated all affected health check configuration and DI extension classes, and removed unnecessary using directives. This streamlines validation and reduces external dependencies.