### PR TITLE
chore: Add Renovate support for Docker images in .cs files

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -13,9 +13,10 @@
   "automergeType": "pr",
   "automergeStrategy": "squash",
   "enabledManagers": [
+    "custom.regex",
+    "docker",
     "github-actions",
-    "nuget",
-    "custom.regex"
+    "nuget"
   ],
   "customManagers": [
     {
@@ -31,6 +32,17 @@
       ],
       "datasourceTemplate": "nuget",
       "versioningTemplate": "nuget"
+    },
+    {
+      "customType": "regex",
+      "fileMatch": [
+        "\\.cs$"
+      ],
+      "matchStrings": [
+        "/\\*dockerimage\\*/\\s*\"(?<depName>[^:]+):(?<currentValue>[^\"]+)\""
+      ],
+      "datasourceTemplate": "docker",
+      "versioningTemplate": "docker"
     }
   ],
   "packageRules": [
@@ -86,6 +98,20 @@
       "matchPackageNames": [
         "TUnit",
         "TUnit.*"
+      ]
+    },
+    {
+      "matchDatasources": [
+        "docker"
+      ],
+      "labels": [
+        "dependency:docker"
+      ],
+      "semanticCommits": "enabled",
+      "semanticCommitType": "chore",
+      "semanticCommitScope": "docker",
+      "assignees": [
+        "samtrion"
       ]
     }
   ]


### PR DESCRIPTION
Added a custom regex manager in renovate.json to detect and update Docker image references in C# files marked with /*dockerimage*/. Also introduced a package rule for Docker dependencies to label PRs, enable semantic commits, and assign them to "samtrion".