### PR TITLE
fix: Switch Renovate manager from docker to dockerfile

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -14,7 +14,7 @@
   "automergeStrategy": "squash",
   "enabledManagers": [
     "custom.regex",
-    "docker",
+    "dockerfile",
     "github-actions",
     "nuget"
   ],


### PR DESCRIPTION
Updated renovate.json to use "dockerfile" instead of "docker" in the enabledManagers list, ensuring Docker-related updates are managed by the correct Renovate manager.