### PR TITLE
test: Refactor DI setup in health check test methods

### DIFF
--- a/tests/NetEvolve.HealthChecks.Tests.Unit/Apache.Pulsar/PulsarHealthCheckTests.cs
+++ b/tests/NetEvolve.HealthChecks.Tests.Unit/Apache.Pulsar/PulsarHealthCheckTests.cs
@@ -15,9 +15,9 @@ public sealed class PulsarHealthCheckTests
     public void CheckHealthAsync_WhenClientNotRegistered_ThrowsException()
     {
         var configuration = new ConfigurationBuilder().Build();
-        var services = new ServiceCollection();
-        _ = services.AddSingleton<IConfiguration>(configuration);
-        _ = services.Configure<PulsarOptions>("test", opt => opt.Timeout = 1000);
+        var services = new ServiceCollection()
+            .AddSingleton<IConfiguration>(configuration)
+            .Configure<PulsarOptions>("test", opt => opt.Timeout = 1000);
 
         var serviceProvider = services.BuildServiceProvider();
         var optionsMonitor = serviceProvider.GetRequiredService<IOptionsMonitor<PulsarOptions>>();

--- a/tests/NetEvolve.HealthChecks.Tests.Unit/Azure.EventHubs/EventHubsClientFactoryTests.cs
+++ b/tests/NetEvolve.HealthChecks.Tests.Unit/Azure.EventHubs/EventHubsClientFactoryTests.cs
@@ -67,8 +67,7 @@ public sealed class EventHubsClientFactoryTests
     {
         // Arrange
         var mockClient = Substitute.For<EventHubProducerClient>();
-        var services = new ServiceCollection();
-        _ = services.AddSingleton(mockClient);
+        var services = new ServiceCollection().AddSingleton(mockClient);
         await using var serviceProvider = services.BuildServiceProvider();
 
         var options = new EventHubsOptions { Mode = ClientCreationMode.ServiceProvider, EventHubName = "eventhub1" };

--- a/tests/NetEvolve.HealthChecks.Tests.Unit/GCP.BigQuery/DependencyInjectionExtensionsTests.cs
+++ b/tests/NetEvolve.HealthChecks.Tests.Unit/GCP.BigQuery/DependencyInjectionExtensionsTests.cs
@@ -63,8 +63,9 @@ public sealed class DependencyInjectionExtensionsTests
     public async Task AddBigQuery_WhenParameterCorrect_RegistrationAdded()
     {
         // Arrange
-        var services = new ServiceCollection();
-        _ = services.AddSingleton<IConfiguration>(new ConfigurationBuilder().AddInMemoryCollection([]).Build());
+        var services = new ServiceCollection().AddSingleton<IConfiguration>(
+            new ConfigurationBuilder().AddInMemoryCollection([]).Build()
+        );
         var builder = services.AddHealthChecks();
         const string name = "Test";
 
@@ -84,8 +85,9 @@ public sealed class DependencyInjectionExtensionsTests
     public async Task AddBigQuery_WhenParameterCorrectWithOptions_RegistrationAdded()
     {
         // Arrange
-        var services = new ServiceCollection();
-        _ = services.AddSingleton<IConfiguration>(new ConfigurationBuilder().AddInMemoryCollection([]).Build());
+        var services = new ServiceCollection().AddSingleton<IConfiguration>(
+            new ConfigurationBuilder().AddInMemoryCollection([]).Build()
+        );
         var builder = services.AddHealthChecks();
         const string name = "Test";
 
@@ -112,8 +114,9 @@ public sealed class DependencyInjectionExtensionsTests
     public void AddBigQuery_WhenDuplicateName_ThrowArgumentException()
     {
         // Arrange
-        var services = new ServiceCollection();
-        _ = services.AddSingleton<IConfiguration>(new ConfigurationBuilder().AddInMemoryCollection([]).Build());
+        var services = new ServiceCollection().AddSingleton<IConfiguration>(
+            new ConfigurationBuilder().AddInMemoryCollection([]).Build()
+        );
         var builder = services.AddHealthChecks();
         const string name = "Test";
 
@@ -127,8 +130,9 @@ public sealed class DependencyInjectionExtensionsTests
     public async Task AddBigQuery_WhenMultipleChecksWithDifferentNames_AllRegistrationsAdded()
     {
         // Arrange
-        var services = new ServiceCollection();
-        _ = services.AddSingleton<IConfiguration>(new ConfigurationBuilder().AddInMemoryCollection([]).Build());
+        var services = new ServiceCollection().AddSingleton<IConfiguration>(
+            new ConfigurationBuilder().AddInMemoryCollection([]).Build()
+        );
         var builder = services.AddHealthChecks();
 
         // Act
@@ -148,8 +152,9 @@ public sealed class DependencyInjectionExtensionsTests
     public async Task AddBigQuery_WhenCustomTags_TagsApplied()
     {
         // Arrange
-        var services = new ServiceCollection();
-        _ = services.AddSingleton<IConfiguration>(new ConfigurationBuilder().AddInMemoryCollection([]).Build());
+        var services = new ServiceCollection().AddSingleton<IConfiguration>(
+            new ConfigurationBuilder().AddInMemoryCollection([]).Build()
+        );
         var builder = services.AddHealthChecks();
         const string name = "Test";
         const string customTag = "custom-tag";

--- a/tests/NetEvolve.HealthChecks.Tests.Unit/GCP.Bigtable/DependencyInjectionExtensionsTests.cs
+++ b/tests/NetEvolve.HealthChecks.Tests.Unit/GCP.Bigtable/DependencyInjectionExtensionsTests.cs
@@ -63,8 +63,9 @@ public sealed class DependencyInjectionExtensionsTests
     public async Task AddBigtable_WhenParameterCorrect_RegistrationAdded()
     {
         // Arrange
-        var services = new ServiceCollection();
-        _ = services.AddSingleton<IConfiguration>(new ConfigurationBuilder().AddInMemoryCollection([]).Build());
+        var services = new ServiceCollection().AddSingleton<IConfiguration>(
+            new ConfigurationBuilder().AddInMemoryCollection([]).Build()
+        );
         var builder = services.AddHealthChecks();
         const string name = "Test";
 
@@ -84,8 +85,9 @@ public sealed class DependencyInjectionExtensionsTests
     public async Task AddBigtable_WhenParameterCorrectWithOptions_RegistrationAdded()
     {
         // Arrange
-        var services = new ServiceCollection();
-        _ = services.AddSingleton<IConfiguration>(new ConfigurationBuilder().AddInMemoryCollection([]).Build());
+        var services = new ServiceCollection().AddSingleton<IConfiguration>(
+            new ConfigurationBuilder().AddInMemoryCollection([]).Build()
+        );
         var builder = services.AddHealthChecks();
         const string name = "Test";
 
@@ -112,8 +114,9 @@ public sealed class DependencyInjectionExtensionsTests
     public void AddBigtable_WhenDuplicateName_ThrowArgumentException()
     {
         // Arrange
-        var services = new ServiceCollection();
-        _ = services.AddSingleton<IConfiguration>(new ConfigurationBuilder().AddInMemoryCollection([]).Build());
+        var services = new ServiceCollection().AddSingleton<IConfiguration>(
+            new ConfigurationBuilder().AddInMemoryCollection([]).Build()
+        );
         var builder = services.AddHealthChecks();
         const string name = "Test";
 
@@ -127,8 +130,9 @@ public sealed class DependencyInjectionExtensionsTests
     public async Task AddBigtable_WhenMultipleChecksWithDifferentNames_AllRegistrationsAdded()
     {
         // Arrange
-        var services = new ServiceCollection();
-        _ = services.AddSingleton<IConfiguration>(new ConfigurationBuilder().AddInMemoryCollection([]).Build());
+        var services = new ServiceCollection().AddSingleton<IConfiguration>(
+            new ConfigurationBuilder().AddInMemoryCollection([]).Build()
+        );
         var builder = services.AddHealthChecks();
 
         // Act
@@ -148,8 +152,9 @@ public sealed class DependencyInjectionExtensionsTests
     public async Task AddBigtable_WhenCustomTags_TagsApplied()
     {
         // Arrange
-        var services = new ServiceCollection();
-        _ = services.AddSingleton<IConfiguration>(new ConfigurationBuilder().AddInMemoryCollection([]).Build());
+        var services = new ServiceCollection().AddSingleton<IConfiguration>(
+            new ConfigurationBuilder().AddInMemoryCollection([]).Build()
+        );
         var builder = services.AddHealthChecks();
         const string name = "Test";
         const string customTag = "custom-tag";

--- a/tests/NetEvolve.HealthChecks.Tests.Unit/GCP.Firestore/DependencyInjectionExtensionsTests.cs
+++ b/tests/NetEvolve.HealthChecks.Tests.Unit/GCP.Firestore/DependencyInjectionExtensionsTests.cs
@@ -63,8 +63,9 @@ public sealed class DependencyInjectionExtensionsTests
     public async Task AddFirestore_WhenParameterCorrect_RegistrationAdded()
     {
         // Arrange
-        var services = new ServiceCollection();
-        _ = services.AddSingleton<IConfiguration>(new ConfigurationBuilder().AddInMemoryCollection([]).Build());
+        var services = new ServiceCollection().AddSingleton<IConfiguration>(
+            new ConfigurationBuilder().AddInMemoryCollection([]).Build()
+        );
         var builder = services.AddHealthChecks();
         const string name = "Test";
 
@@ -84,8 +85,9 @@ public sealed class DependencyInjectionExtensionsTests
     public async Task AddFirestore_WhenParameterCorrectWithOptions_RegistrationAdded()
     {
         // Arrange
-        var services = new ServiceCollection();
-        _ = services.AddSingleton<IConfiguration>(new ConfigurationBuilder().AddInMemoryCollection([]).Build());
+        var services = new ServiceCollection().AddSingleton<IConfiguration>(
+            new ConfigurationBuilder().AddInMemoryCollection([]).Build()
+        );
         var builder = services.AddHealthChecks();
         const string name = "Test";
 
@@ -112,8 +114,9 @@ public sealed class DependencyInjectionExtensionsTests
     public void AddFirestore_WhenDuplicateName_ThrowArgumentException()
     {
         // Arrange
-        var services = new ServiceCollection();
-        _ = services.AddSingleton<IConfiguration>(new ConfigurationBuilder().AddInMemoryCollection([]).Build());
+        var services = new ServiceCollection().AddSingleton<IConfiguration>(
+            new ConfigurationBuilder().AddInMemoryCollection([]).Build()
+        );
         var builder = services.AddHealthChecks();
         const string name = "Test";
 
@@ -127,8 +130,9 @@ public sealed class DependencyInjectionExtensionsTests
     public async Task AddFirestore_WhenMultipleChecksWithDifferentNames_AllRegistrationsAdded()
     {
         // Arrange
-        var services = new ServiceCollection();
-        _ = services.AddSingleton<IConfiguration>(new ConfigurationBuilder().AddInMemoryCollection([]).Build());
+        var services = new ServiceCollection().AddSingleton<IConfiguration>(
+            new ConfigurationBuilder().AddInMemoryCollection([]).Build()
+        );
         var builder = services.AddHealthChecks();
 
         // Act
@@ -148,8 +152,9 @@ public sealed class DependencyInjectionExtensionsTests
     public async Task AddFirestore_WhenCustomTags_TagsApplied()
     {
         // Arrange
-        var services = new ServiceCollection();
-        _ = services.AddSingleton<IConfiguration>(new ConfigurationBuilder().AddInMemoryCollection([]).Build());
+        var services = new ServiceCollection().AddSingleton<IConfiguration>(
+            new ConfigurationBuilder().AddInMemoryCollection([]).Build()
+        );
         var builder = services.AddHealthChecks();
         const string name = "Test";
         const string customTag = "custom-tag";

--- a/tests/NetEvolve.HealthChecks.Tests.Unit/GCP.PubSub/DependencyInjectionExtensionsTests.cs
+++ b/tests/NetEvolve.HealthChecks.Tests.Unit/GCP.PubSub/DependencyInjectionExtensionsTests.cs
@@ -63,8 +63,9 @@ public sealed class DependencyInjectionExtensionsTests
     public async Task AddPubSub_WhenParameterCorrect_RegistrationAdded()
     {
         // Arrange
-        var services = new ServiceCollection();
-        _ = services.AddSingleton<IConfiguration>(new ConfigurationBuilder().AddInMemoryCollection([]).Build());
+        var services = new ServiceCollection().AddSingleton<IConfiguration>(
+            new ConfigurationBuilder().AddInMemoryCollection([]).Build()
+        );
         var builder = services.AddHealthChecks();
         const string name = "Test";
 
@@ -84,8 +85,9 @@ public sealed class DependencyInjectionExtensionsTests
     public async Task AddPubSub_WhenParameterCorrectWithOptions_RegistrationAdded()
     {
         // Arrange
-        var services = new ServiceCollection();
-        _ = services.AddSingleton<IConfiguration>(new ConfigurationBuilder().AddInMemoryCollection([]).Build());
+        var services = new ServiceCollection().AddSingleton<IConfiguration>(
+            new ConfigurationBuilder().AddInMemoryCollection([]).Build()
+        );
         var builder = services.AddHealthChecks();
         const string name = "Test";
 
@@ -112,8 +114,9 @@ public sealed class DependencyInjectionExtensionsTests
     public void AddPubSub_WhenDuplicateName_ThrowArgumentException()
     {
         // Arrange
-        var services = new ServiceCollection();
-        _ = services.AddSingleton<IConfiguration>(new ConfigurationBuilder().AddInMemoryCollection([]).Build());
+        var services = new ServiceCollection().AddSingleton<IConfiguration>(
+            new ConfigurationBuilder().AddInMemoryCollection([]).Build()
+        );
         var builder = services.AddHealthChecks();
         const string name = "Test";
 
@@ -127,8 +130,9 @@ public sealed class DependencyInjectionExtensionsTests
     public async Task AddPubSub_WhenMultipleChecksWithDifferentNames_AllRegistrationsAdded()
     {
         // Arrange
-        var services = new ServiceCollection();
-        _ = services.AddSingleton<IConfiguration>(new ConfigurationBuilder().AddInMemoryCollection([]).Build());
+        var services = new ServiceCollection().AddSingleton<IConfiguration>(
+            new ConfigurationBuilder().AddInMemoryCollection([]).Build()
+        );
         var builder = services.AddHealthChecks();
 
         // Act
@@ -148,8 +152,9 @@ public sealed class DependencyInjectionExtensionsTests
     public async Task AddPubSub_WhenCustomTags_TagsApplied()
     {
         // Arrange
-        var services = new ServiceCollection();
-        _ = services.AddSingleton<IConfiguration>(new ConfigurationBuilder().AddInMemoryCollection([]).Build());
+        var services = new ServiceCollection().AddSingleton<IConfiguration>(
+            new ConfigurationBuilder().AddInMemoryCollection([]).Build()
+        );
         var builder = services.AddHealthChecks();
         const string name = "Test";
         const string customTag = "custom-tag";

--- a/tests/NetEvolve.HealthChecks.Tests.Unit/Http/DependencyInjectionExtensionsTests.cs
+++ b/tests/NetEvolve.HealthChecks.Tests.Unit/Http/DependencyInjectionExtensionsTests.cs
@@ -49,8 +49,9 @@ public sealed class DependencyInjectionExtensionsTests
     public async Task AddHttp_WhenParameterCorrect_ServiceAdded()
     {
         // Arrange
-        var services = new ServiceCollection();
-        _ = services.AddSingleton<IConfiguration>(new ConfigurationBuilder().AddInMemoryCollection([]).Build());
+        var services = new ServiceCollection().AddSingleton<IConfiguration>(
+            new ConfigurationBuilder().AddInMemoryCollection([]).Build()
+        );
         var builder = services.AddHealthChecks();
         const string name = "Test";
 
@@ -68,8 +69,9 @@ public sealed class DependencyInjectionExtensionsTests
     public async Task AddHttp_WhenParameterCorrectWithOptions_ServiceAdded()
     {
         // Arrange
-        var services = new ServiceCollection();
-        _ = services.AddSingleton<IConfiguration>(new ConfigurationBuilder().AddInMemoryCollection([]).Build());
+        var services = new ServiceCollection().AddSingleton<IConfiguration>(
+            new ConfigurationBuilder().AddInMemoryCollection([]).Build()
+        );
         var builder = services.AddHealthChecks();
         const string name = "Test";
 


### PR DESCRIPTION
Refactor ServiceCollection setup in test methods to use method chaining for adding IConfiguration and other services. Improves readability and consistency across tests for BigQuery, Bigtable, Firestore, PubSub, and HTTP health checks. No changes to test logic or functionality.