### PR TITLE
fix: Suppress CA2025 warnings in RabbitMQ health check tests

### DIFF
--- a/tests/NetEvolve.HealthChecks.Tests.Unit/RabbitMQ/RabbitMQHealthCheckTests.cs
+++ b/tests/NetEvolve.HealthChecks.Tests.Unit/RabbitMQ/RabbitMQHealthCheckTests.cs
@@ -1,6 +1,7 @@
 ﻿namespace NetEvolve.HealthChecks.Tests.Unit.RabbitMQ;
 
 using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Threading;
 using System.Threading.Tasks;
 using global::RabbitMQ.Client;
@@ -18,6 +19,11 @@ public sealed class RabbitMQHealthCheckTests
     private const string TestName = nameof(RabbitMQ);
 
     [Test]
+    [SuppressMessage(
+        "Reliability",
+        "CA2025:Do not pass 'IDisposable' instances into unawaited tasks",
+        Justification = "As designed."
+    )]
     public async Task CheckHealthAsync_WithKeyedService_UsesKeyedService()
     {
         // Arrange
@@ -56,6 +62,11 @@ public sealed class RabbitMQHealthCheckTests
     }
 
     [Test]
+    [SuppressMessage(
+        "Reliability",
+        "CA2025:Do not pass 'IDisposable' instances into unawaited tasks",
+        Justification = "As designed."
+    )]
     public async Task CheckHealthAsync_WithoutKeyedService_UsesDefaultService()
     {
         // Arrange


### PR DESCRIPTION
Added SuppressMessage attributes to two test methods in RabbitMQHealthCheckTests to suppress CA2025 ("Do not pass 'IDisposable' instances into unawaited tasks") warnings, with justification "As designed." Imported System.Diagnostics.CodeAnalysis to support these attributes. This ensures intentional test design is not flagged by static analysis.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added unit tests for RabbitMQ health check functionality to validate both keyed service and default service scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->