### PR TITLE
fix: Update emulator Docker images to use '-emulators' tag

### DIFF
--- a/tests/NetEvolve.HealthChecks.Tests.Integration/GCP.Bigtable/BigtableDatabase.cs
+++ b/tests/NetEvolve.HealthChecks.Tests.Integration/GCP.Bigtable/BigtableDatabase.cs
@@ -11,7 +11,7 @@ using TUnit.Core.Interfaces;
 public sealed class BigtableDatabase : IAsyncInitializer, IAsyncDisposable
 {
     private readonly BigtableContainer _container = new BigtableBuilder(
-        /*dockerimage*/"gcr.io/google.com/cloudsdktool/google-cloud-cli:446.0.1"
+        /*dockerimage*/"gcr.io/google.com/cloudsdktool/google-cloud-cli:446.0.1-emulators"
     )
         .WithLogger(NullLogger.Instance)
         .Build();

--- a/tests/NetEvolve.HealthChecks.Tests.Integration/GCP.Firestore/FirestoreDatabase.cs
+++ b/tests/NetEvolve.HealthChecks.Tests.Integration/GCP.Firestore/FirestoreDatabase.cs
@@ -12,7 +12,7 @@ using TUnit.Core.Interfaces;
 public sealed class FirestoreDatabase : IAsyncInitializer, IAsyncDisposable
 {
     private readonly FirestoreContainer _container = new FirestoreBuilder(
-        /*dockerimage*/"gcr.io/google.com/cloudsdktool/google-cloud-cli:446.0.1"
+        /*dockerimage*/"gcr.io/google.com/cloudsdktool/google-cloud-cli:446.0.1-emulators"
     )
         .WithLogger(NullLogger.Instance)
         .Build();

--- a/tests/NetEvolve.HealthChecks.Tests.Integration/GCP.PubSub/PubSubEmulator.cs
+++ b/tests/NetEvolve.HealthChecks.Tests.Integration/GCP.PubSub/PubSubEmulator.cs
@@ -11,7 +11,7 @@ using TUnit.Core.Interfaces;
 public sealed class PubSubEmulator : IAsyncInitializer, IAsyncDisposable
 {
     private readonly PubSubContainer _container = new PubSubBuilder(
-        /*dockerimage*/"gcr.io/google.com/cloudsdktool/google-cloud-cli:446.0.1"
+        /*dockerimage*/"gcr.io/google.com/cloudsdktool/google-cloud-cli:446.0.1-emulators"
     )
         .WithLogger(NullLogger.Instance)
         .Build();


### PR DESCRIPTION
Switched the Cloud SDK Docker image in BigtableDatabase, FirestoreDatabase, and PubSubEmulator to use the
'google-cloud-cli:446.0.1-emulators' tag. This ensures the containers include the required emulator components.