### PR TITLE
fix: Downgrade AWSSDK.SQS and handle resource creation errors

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -27,7 +27,7 @@
     <PackageVersion Include="AWSSDK.EC2" Version="4.0.82" />
     <PackageVersion Include="AWSSDK.S3" Version="4.0.19.1" />
     <PackageVersion Include="AWSSDK.SimpleNotificationService" Version="4.0.2.20" />
-    <PackageVersion Include="AWSSDK.SQS" Version="4.0.2.18" />
+    <PackageVersion Include="AWSSDK.SQS" Version="4.0.2.1" />
     <PackageVersion Include="Azure.Data.Tables" Version="12.11.0" />
     <PackageVersion Include="Azure.Identity" Version="1.18.0" />
     <PackageVersion Include="Azure.Messaging.EventHubs" Version="5.12.2" />

--- a/tests/NetEvolve.HealthChecks.Tests.Integration/AWS/LocalStackInstance.cs
+++ b/tests/NetEvolve.HealthChecks.Tests.Integration/AWS/LocalStackInstance.cs
@@ -99,67 +99,94 @@ public sealed class LocalStackInstance : IAsyncInitializer, IAsyncDisposable
 
     private async Task CreateSQSDefaults(CancellationToken cancellationToken)
     {
-        // Create SQS Queue
-        using var sqsClient = new AmazonSQSClient(
-            AccessKey,
-            SecretKey,
-            new AmazonSQSConfig { ServiceURL = ConnectionString }
-        );
-
-        _ = await sqsClient.CreateQueueAsync(QueueName, cancellationToken).ConfigureAwait(false);
+        try
+        {
+            // Create SQS Queue
+            using var sqsClient = new AmazonSQSClient(
+                AccessKey,
+                SecretKey,
+                new AmazonSQSConfig { ServiceURL = ConnectionString }
+            );
+            _ = await sqsClient.CreateQueueAsync(QueueName, cancellationToken).ConfigureAwait(false);
+        }
+        catch
+        {
+            // Ignore
+        }
     }
 
     private async Task CreateS3Defaults(CancellationToken cancellationToken)
     {
-        // Create S3 Bucket
-        using var s3Client = new AmazonS3Client(
-            AccessKey,
-            SecretKey,
-            new AmazonS3Config { ServiceURL = ConnectionString, ForcePathStyle = true }
-        );
+        try
+        {
+            // Create S3 Bucket
+            using var s3Client = new AmazonS3Client(
+                AccessKey,
+                SecretKey,
+                new AmazonS3Config { ServiceURL = ConnectionString, ForcePathStyle = true }
+            );
 
-        var putBucketRequest = new PutBucketRequest { BucketName = BucketName };
-        _ = await s3Client.PutBucketAsync(putBucketRequest, cancellationToken).ConfigureAwait(false);
+            var putBucketRequest = new PutBucketRequest { BucketName = BucketName };
+            _ = await s3Client.PutBucketAsync(putBucketRequest, cancellationToken).ConfigureAwait(false);
+        }
+        catch
+        {
+            // Ignore
+        }
     }
 
     private async Task CreateEC2DEfaults(CancellationToken cancellationToken)
     {
-        // Create EC2 Defaults if needed
-        using var ec2Client = new AmazonEC2Client(
-            AccessKey,
-            SecretKey,
-            new AmazonEC2Config { ServiceURL = ConnectionString }
-        );
-
-        var request = new RunInstancesRequest()
+        try
         {
-            InstanceType = InstanceType.T1Micro,
-            MinCount = 1,
-            MaxCount = 1,
-            KeyName = "development",
-        };
-        _ = await ec2Client.RunInstancesAsync(request, cancellationToken).ConfigureAwait(false);
+            // Create EC2 Defaults if needed
+            using var ec2Client = new AmazonEC2Client(
+                AccessKey,
+                SecretKey,
+                new AmazonEC2Config { ServiceURL = ConnectionString }
+            );
+
+            var request = new RunInstancesRequest()
+            {
+                InstanceType = InstanceType.T1Micro,
+                MinCount = 1,
+                MaxCount = 1,
+                KeyName = "development",
+            };
+            _ = await ec2Client.RunInstancesAsync(request, cancellationToken).ConfigureAwait(false);
+        }
+        catch
+        {
+            // Ignore
+        }
     }
 
     private async Task CreateDynamoDBDefaults(CancellationToken cancellationToken)
     {
-        // Create DynamoDB Table
-        using var dynamoDbClient = new AmazonDynamoDBClient(
-            AccessKey,
-            SecretKey,
-            new AmazonDynamoDBConfig { ServiceURL = ConnectionString }
-        );
-
-        var createTableRequest = new CreateTableRequest
+        try
         {
-            TableName = TableName,
-            KeySchema = [new KeySchemaElement { AttributeName = "Id", KeyType = Amazon.DynamoDBv2.KeyType.HASH }],
-            AttributeDefinitions =
-            [
-                new AttributeDefinition { AttributeName = "Id", AttributeType = ScalarAttributeType.S },
-            ],
-            BillingMode = BillingMode.PAY_PER_REQUEST,
-        };
-        _ = await dynamoDbClient.CreateTableAsync(createTableRequest, cancellationToken).ConfigureAwait(false);
+            // Create DynamoDB Table
+            using var dynamoDbClient = new AmazonDynamoDBClient(
+                AccessKey,
+                SecretKey,
+                new AmazonDynamoDBConfig { ServiceURL = ConnectionString }
+            );
+
+            var createTableRequest = new CreateTableRequest
+            {
+                TableName = TableName,
+                KeySchema = [new KeySchemaElement { AttributeName = "Id", KeyType = Amazon.DynamoDBv2.KeyType.HASH }],
+                AttributeDefinitions =
+                [
+                    new AttributeDefinition { AttributeName = "Id", AttributeType = ScalarAttributeType.S },
+                ],
+                BillingMode = BillingMode.PAY_PER_REQUEST,
+            };
+            _ = await dynamoDbClient.CreateTableAsync(createTableRequest, cancellationToken).ConfigureAwait(false);
+        }
+        catch
+        {
+            // Ignore
+        }
     }
 }


### PR DESCRIPTION
Downgraded AWSSDK.SQS package from 4.0.2.18 to 4.0.2.1. Updated LocalStackInstance resource creation methods (SQS, S3, EC2, DynamoDB) to catch and ignore exceptions, preventing failures from propagating during resource setup.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated a cloud service SDK dependency version.

* **Tests**
  * Added exception handling to service initialization logic in integration tests to improve robustness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->