### PR TITLE
chore: Replaced `Testcontainers.LocalStack`with `Testcontainers.Floci`

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -142,7 +142,7 @@
     <PackageVersion Include="Testcontainers.Keycloak" Version="4.12.0" />
     <PackageVersion Include="Testcontainers.KurrentDb" Version="4.12.0" />
     <PackageVersion Include="Testcontainers.Kusto" Version="4.12.0" />
-    <PackageVersion Include="Testcontainers.LocalStack" Version="4.12.0" />
+    <PackageVersion Include="Testcontainers.Floci" Version="4.12.0" />
     <PackageVersion Include="Testcontainers.MariaDb" Version="4.12.0" />
     <PackageVersion Include="Testcontainers.Milvus" Version="4.12.0" />
     <PackageVersion Include="Testcontainers.Minio" Version="4.12.0" />

--- a/src/NetEvolve.HealthChecks.AWS.EC2/ElasticComputeCloudHealthCheck.cs
+++ b/src/NetEvolve.HealthChecks.AWS.EC2/ElasticComputeCloudHealthCheck.cs
@@ -21,14 +21,10 @@ internal sealed partial class ElasticComputeCloudHealthCheck
     {
         using var client = CreateClient(options);
 
-        var request = new DescribeInstancesRequest
-        {
-            MaxResults = 1,
-            Filters = [new Filter("key-name", [options.KeyName])],
-        };
+        var request = new DescribeKeyPairsRequest { KeyNames = [options.KeyName] };
 
         var (isTimelyResponse, response) = await client
-            .DescribeInstancesAsync(request, cancellationToken)
+            .DescribeKeyPairsAsync(request, cancellationToken)
             .WithTimeoutAsync(options.Timeout, cancellationToken)
             .ConfigureAwait(false);
 
@@ -41,13 +37,9 @@ internal sealed partial class ElasticComputeCloudHealthCheck
             );
         }
 
-        var isHealthy = response
-            .Reservations.SelectMany(x => x.Instances)
-            .Any(x => x.State.Name == InstanceStateName.Running || x.State.Name == InstanceStateName.Pending);
-
-        if (!isHealthy)
+        if (response.KeyPairs.Count == 0)
         {
-            return HealthCheckUnhealthy(failureStatus, name, "No running instances found.");
+            return HealthCheckUnhealthy(failureStatus, name, $"No key pair with name '{options.KeyName}' found.");
         }
 
         return HealthCheckState(isTimelyResponse, name);

--- a/src/SourceGenerator.HealthChecks/CodeGenerator.cs
+++ b/src/SourceGenerator.HealthChecks/CodeGenerator.cs
@@ -37,7 +37,7 @@ internal static class CodeGenerator
                 includeServiceProvider,
                 $"partial class {candidate.Name}(IServiceProvider serviceProvider, IOptionsMonitor<{candidate.OptionsTypeNamespace}.{candidate.OptionsTypeName}> optionsMonitor)"
             )
-            .Intend()
+            .Indent()
             .AppendLine(": IHealthCheck");
 
         using (cb.Scope())

--- a/src/SourceGenerator.HealthChecks/Generators/ConfigurableHealthCheckGenerator.cs
+++ b/src/SourceGenerator.HealthChecks/Generators/ConfigurableHealthCheckGenerator.cs
@@ -39,7 +39,7 @@ internal sealed class ConfigurableHealthCheckGenerator : IIncrementalGenerator
             .AppendLine()
             .AppendLine("[MethodImpl(MethodImplOptions.AggressiveInlining)]")
             .AppendLine("private static HealthCheckResult HealthCheckState(bool condition, string name) =>")
-            .Intend()
+            .Indent()
             .AppendLine("condition ? HealthCheckResult.Healthy($\"{name}: Healthy\") : HealthCheckDegraded(name);");
 
         _ = builder
@@ -48,14 +48,14 @@ internal sealed class ConfigurableHealthCheckGenerator : IIncrementalGenerator
             .AppendLine(
                 "private static HealthCheckResult HealthCheckUnhealthy(HealthStatus failureStatus, string name, string message = \"Unhealthy\", Exception? ex = null) =>"
             )
-            .Intend()
+            .Indent()
             .AppendLine("new HealthCheckResult(failureStatus, $\"{name}: {message}\", exception: ex);");
 
         _ = builder
             .AppendLine()
             .AppendLine("[MethodImpl(MethodImplOptions.AggressiveInlining)]")
             .AppendLine("private static HealthCheckResult HealthCheckDegraded(string name) =>")
-            .Intend()
+            .Indent()
             .AppendLine("HealthCheckResult.Degraded($\"{name}: Degraded\");");
     }
 

--- a/src/SourceGenerator.HealthChecks/Generators/DependencyExtensionsGenerator.cs
+++ b/src/SourceGenerator.HealthChecks/Generators/DependencyExtensionsGenerator.cs
@@ -83,9 +83,9 @@ internal sealed class DependencyExtensionsGenerator : IIncrementalGenerator
                 _ = builder
                     .AppendLine("[ExcludeFromCodeCoverage]")
                     .AppendLine("bool IsNameAlreadyUsedForServiceType(HealthCheckRegistration registration) =>")
-                    .Intend()
+                    .Indent()
                     .AppendLine("registration.Name.Equals(name, StringComparison.OrdinalIgnoreCase)")
-                    .Intend()
+                    .Indent()
                     .AppendLine("&& registration.Factory(scope.ServiceProvider).GetType() == typeof(T);");
             }
         }

--- a/src/SourceGenerator.HealthChecks/Generators/SqlHealthCheckGenerator.cs
+++ b/src/SourceGenerator.HealthChecks/Generators/SqlHealthCheckGenerator.cs
@@ -39,14 +39,14 @@ internal sealed class SqlHealthCheckGenerator : IIncrementalGenerator
             .Append("private ")
             .AppendIf(candidate.AsyncImplementation, "async ")
             .AppendLine("ValueTask<HealthCheckResult> ExecuteHealthCheckAsync(")
-            .Intend()
+            .Indent()
             .AppendLine("string name,")
-            .Intend()
+            .Indent()
             .AppendLine("HealthStatus failureStatus,")
-            .Intend()
+            .Indent()
             .Append(candidate.OptionsTypeName)
             .AppendLine(" options,")
-            .Intend()
+            .Indent()
             .AppendLine("CancellationToken cancellationToken)");
         using (builder.Scope())
         {

--- a/tests/NetEvolve.HealthChecks.Tests.Integration/AWS.DynamoDB/DynamoDbHealthCheckTests.cs
+++ b/tests/NetEvolve.HealthChecks.Tests.Integration/AWS.DynamoDB/DynamoDbHealthCheckTests.cs
@@ -11,12 +11,12 @@ using NetEvolve.HealthChecks.Tests.Integration.AWS;
 
 [TestGroup($"{nameof(AWS)}.{nameof(DynamoDB)}")]
 [TestGroup("Z01TestGroup")]
-[ClassDataSource<LocalStackInstance>(Shared = SharedType.PerClass)]
+[ClassDataSource<FlociStackInstance>(Shared = SharedType.PerClass)]
 public class DynamoDbHealthCheckTests : HealthCheckTestBase
 {
-    private readonly LocalStackInstance _instance;
+    private readonly FlociStackInstance _instance;
 
-    public DynamoDbHealthCheckTests(LocalStackInstance instance) => _instance = instance;
+    public DynamoDbHealthCheckTests(FlociStackInstance instance) => _instance = instance;
 
     [Test]
     public async Task AddAWSDynamoDB_UseOptionsCreate_Healthy() =>
@@ -27,10 +27,10 @@ public class DynamoDbHealthCheckTests : HealthCheckTestBase
                     "TestContainerHealthy",
                     options =>
                     {
-                        options.AccessKey = LocalStackInstance.AccessKey;
-                        options.SecretKey = LocalStackInstance.SecretKey;
+                        options.AccessKey = FlociStackInstance.AccessKey;
+                        options.SecretKey = FlociStackInstance.SecretKey;
                         options.ServiceUrl = _instance.ConnectionString;
-                        options.TableName = LocalStackInstance.TableName;
+                        options.TableName = FlociStackInstance.TableName;
                         options.Mode = CreationMode.BasicAuthentication;
                         options.Timeout = 10000; // Set a reasonable timeout
                     }
@@ -48,8 +48,8 @@ public class DynamoDbHealthCheckTests : HealthCheckTestBase
                     "TestContainerUnhealthy",
                     options =>
                     {
-                        options.AccessKey = LocalStackInstance.AccessKey;
-                        options.SecretKey = LocalStackInstance.SecretKey;
+                        options.AccessKey = FlociStackInstance.AccessKey;
+                        options.SecretKey = FlociStackInstance.SecretKey;
                         options.ServiceUrl = _instance.ConnectionString;
                         options.TableName = "invalid-table";
                         options.Mode = CreationMode.BasicAuthentication;
@@ -68,10 +68,10 @@ public class DynamoDbHealthCheckTests : HealthCheckTestBase
                     "TestContainerDegraded",
                     options =>
                     {
-                        options.AccessKey = LocalStackInstance.AccessKey;
-                        options.SecretKey = LocalStackInstance.SecretKey;
+                        options.AccessKey = FlociStackInstance.AccessKey;
+                        options.SecretKey = FlociStackInstance.SecretKey;
                         options.ServiceUrl = _instance.ConnectionString;
-                        options.TableName = LocalStackInstance.TableName;
+                        options.TableName = FlociStackInstance.TableName;
                         options.Timeout = 0;
                         options.Mode = CreationMode.BasicAuthentication;
                     }
@@ -89,9 +89,9 @@ public class DynamoDbHealthCheckTests : HealthCheckTestBase
             {
                 var values = new Dictionary<string, string?>(StringComparer.Ordinal)
                 {
-                    ["HealthChecks:AWSDynamoDB:TestContainerHealthy:AccessKey"] = LocalStackInstance.AccessKey,
-                    ["HealthChecks:AWSDynamoDB:TestContainerHealthy:TableName"] = LocalStackInstance.TableName,
-                    ["HealthChecks:AWSDynamoDB:TestContainerHealthy:SecretKey"] = LocalStackInstance.SecretKey,
+                    ["HealthChecks:AWSDynamoDB:TestContainerHealthy:AccessKey"] = FlociStackInstance.AccessKey,
+                    ["HealthChecks:AWSDynamoDB:TestContainerHealthy:TableName"] = FlociStackInstance.TableName,
+                    ["HealthChecks:AWSDynamoDB:TestContainerHealthy:SecretKey"] = FlociStackInstance.SecretKey,
                     ["HealthChecks:AWSDynamoDB:TestContainerHealthy:ServiceUrl"] = _instance.ConnectionString,
                     ["HealthChecks:AWSDynamoDB:TestContainerHealthy:Mode"] = "BasicAuthentication",
                     ["HealthChecks:AWSDynamoDB:TestContainerHealthy:Timeout"] = "10000",
@@ -110,9 +110,9 @@ public class DynamoDbHealthCheckTests : HealthCheckTestBase
             {
                 var values = new Dictionary<string, string?>(StringComparer.Ordinal)
                 {
-                    ["HealthChecks:AWSDynamoDB:TestContainerDegraded:AccessKey"] = LocalStackInstance.AccessKey,
-                    ["HealthChecks:AWSDynamoDB:TestContainerDegraded:TableName"] = LocalStackInstance.TableName,
-                    ["HealthChecks:AWSDynamoDB:TestContainerDegraded:SecretKey"] = LocalStackInstance.SecretKey,
+                    ["HealthChecks:AWSDynamoDB:TestContainerDegraded:AccessKey"] = FlociStackInstance.AccessKey,
+                    ["HealthChecks:AWSDynamoDB:TestContainerDegraded:TableName"] = FlociStackInstance.TableName,
+                    ["HealthChecks:AWSDynamoDB:TestContainerDegraded:SecretKey"] = FlociStackInstance.SecretKey,
                     ["HealthChecks:AWSDynamoDB:TestContainerDegraded:ServiceUrl"] = _instance.ConnectionString,
                     ["HealthChecks:AWSDynamoDB:TestContainerDegraded:Mode"] = "BasicAuthentication",
                     ["HealthChecks:AWSDynamoDB:TestContainerDegraded:Timeout"] = "0",
@@ -131,9 +131,9 @@ public class DynamoDbHealthCheckTests : HealthCheckTestBase
             {
                 var values = new Dictionary<string, string?>(StringComparer.Ordinal)
                 {
-                    ["HealthChecks:AWSDynamoDB:TestContainerUnhealthy:AccessKey"] = LocalStackInstance.AccessKey,
+                    ["HealthChecks:AWSDynamoDB:TestContainerUnhealthy:AccessKey"] = FlociStackInstance.AccessKey,
                     ["HealthChecks:AWSDynamoDB:TestContainerUnhealthy:TableName"] = "invalid-table",
-                    ["HealthChecks:AWSDynamoDB:TestContainerUnhealthy:SecretKey"] = LocalStackInstance.SecretKey,
+                    ["HealthChecks:AWSDynamoDB:TestContainerUnhealthy:SecretKey"] = FlociStackInstance.SecretKey,
                     ["HealthChecks:AWSDynamoDB:TestContainerUnhealthy:ServiceUrl"] = _instance.ConnectionString,
                     ["HealthChecks:AWSDynamoDB:TestContainerUnhealthy:Mode"] = "BasicAuthentication",
                 };

--- a/tests/NetEvolve.HealthChecks.Tests.Integration/AWS.EC2/ElasticComputeCloudHealthCheckTests.cs
+++ b/tests/NetEvolve.HealthChecks.Tests.Integration/AWS.EC2/ElasticComputeCloudHealthCheckTests.cs
@@ -11,12 +11,18 @@ using NetEvolve.HealthChecks.Tests.Integration.AWS;
 
 [TestGroup($"{nameof(AWS)}.{nameof(EC2)}")]
 [TestGroup("Z01TestGroup")]
-[ClassDataSource<LocalStackInstance>(Shared = SharedType.PerClass)]
+[ClassDataSource<FlociStackInstance>(Shared = SharedType.PerClass)]
 public class ElasticComputeCloudHealthCheckTests : HealthCheckTestBase
 {
-    private readonly LocalStackInstance _instance;
+    private readonly FlociStackInstance _instance;
 
-    public ElasticComputeCloudHealthCheckTests(LocalStackInstance instance) => _instance = instance;
+    public ElasticComputeCloudHealthCheckTests(FlociStackInstance instance) => _instance = instance;
+
+    [Before(Test)]
+    public async Task SetupEC2InstanceAsync()
+    {
+        await _instance.CreateEC2InstanceAsync().ConfigureAwait(false);
+    }
 
     [Test]
     public async Task AddAWSEC2_UseOptionsCreate_Healthy() =>
@@ -27,9 +33,9 @@ public class ElasticComputeCloudHealthCheckTests : HealthCheckTestBase
                     "TestContainerHealthy",
                     options =>
                     {
-                        options.AccessKey = LocalStackInstance.AccessKey;
+                        options.AccessKey = FlociStackInstance.AccessKey;
                         options.KeyName = "development";
-                        options.SecretKey = LocalStackInstance.SecretKey;
+                        options.SecretKey = FlociStackInstance.SecretKey;
                         options.ServiceUrl = _instance.ConnectionString;
                         options.Mode = CreationMode.BasicAuthentication;
                         options.Timeout = 10000; // Set a reasonable timeout
@@ -48,9 +54,9 @@ public class ElasticComputeCloudHealthCheckTests : HealthCheckTestBase
                     "TestContainerDegraded",
                     options =>
                     {
-                        options.AccessKey = LocalStackInstance.AccessKey;
+                        options.AccessKey = FlociStackInstance.AccessKey;
                         options.KeyName = "development";
-                        options.SecretKey = LocalStackInstance.SecretKey;
+                        options.SecretKey = FlociStackInstance.SecretKey;
                         options.ServiceUrl = _instance.ConnectionString;
                         options.Timeout = 0;
                         options.Mode = CreationMode.BasicAuthentication;
@@ -71,9 +77,9 @@ public class ElasticComputeCloudHealthCheckTests : HealthCheckTestBase
             {
                 var values = new Dictionary<string, string?>(StringComparer.Ordinal)
                 {
-                    ["HealthChecks:AWSEC2:TestContainerHealthy:AccessKey"] = LocalStackInstance.AccessKey,
+                    ["HealthChecks:AWSEC2:TestContainerHealthy:AccessKey"] = FlociStackInstance.AccessKey,
                     ["HealthChecks:AWSEC2:TestContainerHealthy:KeyName"] = "development",
-                    ["HealthChecks:AWSEC2:TestContainerHealthy:SecretKey"] = LocalStackInstance.SecretKey,
+                    ["HealthChecks:AWSEC2:TestContainerHealthy:SecretKey"] = FlociStackInstance.SecretKey,
                     ["HealthChecks:AWSEC2:TestContainerHealthy:ServiceUrl"] = _instance.ConnectionString,
                     ["HealthChecks:AWSEC2:TestContainerHealthy:Mode"] = "BasicAuthentication",
                     ["HealthChecks:AWSEC2:TestContainerHealthy:Timeout"] = "10000",
@@ -92,9 +98,9 @@ public class ElasticComputeCloudHealthCheckTests : HealthCheckTestBase
             {
                 var values = new Dictionary<string, string?>(StringComparer.Ordinal)
                 {
-                    ["HealthChecks:AWSEC2:TestContainerDegraded:AccessKey"] = LocalStackInstance.AccessKey,
+                    ["HealthChecks:AWSEC2:TestContainerDegraded:AccessKey"] = FlociStackInstance.AccessKey,
                     ["HealthChecks:AWSEC2:TestContainerDegraded:KeyName"] = "development",
-                    ["HealthChecks:AWSEC2:TestContainerDegraded:SecretKey"] = LocalStackInstance.SecretKey,
+                    ["HealthChecks:AWSEC2:TestContainerDegraded:SecretKey"] = FlociStackInstance.SecretKey,
                     ["HealthChecks:AWSEC2:TestContainerDegraded:ServiceUrl"] = _instance.ConnectionString,
                     ["HealthChecks:AWSEC2:TestContainerDegraded:Mode"] = "BasicAuthentication",
                     ["HealthChecks:AWSEC2:TestContainerDegraded:Timeout"] = "0",
@@ -115,9 +121,9 @@ public class ElasticComputeCloudHealthCheckTests : HealthCheckTestBase
             {
                 var values = new Dictionary<string, string?>(StringComparer.Ordinal)
                 {
-                    ["HealthChecks:AWSEC2:TestContainerWithTags:AccessKey"] = LocalStackInstance.AccessKey,
+                    ["HealthChecks:AWSEC2:TestContainerWithTags:AccessKey"] = FlociStackInstance.AccessKey,
                     ["HealthChecks:AWSEC2:TestContainerWithTags:KeyName"] = "development",
-                    ["HealthChecks:AWSEC2:TestContainerWithTags:SecretKey"] = LocalStackInstance.SecretKey,
+                    ["HealthChecks:AWSEC2:TestContainerWithTags:SecretKey"] = FlociStackInstance.SecretKey,
                     ["HealthChecks:AWSEC2:TestContainerWithTags:ServiceUrl"] = _instance.ConnectionString,
                     ["HealthChecks:AWSEC2:TestContainerWithTags:Mode"] = "BasicAuthentication",
                     ["HealthChecks:AWSEC2:TestContainerWithTags:Timeout"] = "10000",

--- a/tests/NetEvolve.HealthChecks.Tests.Integration/AWS.EC2/ElasticComputeCloudHealthCheckTests.cs
+++ b/tests/NetEvolve.HealthChecks.Tests.Integration/AWS.EC2/ElasticComputeCloudHealthCheckTests.cs
@@ -19,10 +19,7 @@ public class ElasticComputeCloudHealthCheckTests : HealthCheckTestBase
     public ElasticComputeCloudHealthCheckTests(FlociStackInstance instance) => _instance = instance;
 
     [Before(Test)]
-    public async Task SetupEC2InstanceAsync()
-    {
-        await _instance.CreateEC2InstanceAsync().ConfigureAwait(false);
-    }
+    public async Task SetupEC2InstanceAsync() => await _instance.CreateEC2InstanceAsync().ConfigureAwait(false);
 
     [Test]
     public async Task AddAWSEC2_UseOptionsCreate_Healthy() =>

--- a/tests/NetEvolve.HealthChecks.Tests.Integration/AWS.S3/SimpleStorageServiceHealthCheckTests.cs
+++ b/tests/NetEvolve.HealthChecks.Tests.Integration/AWS.S3/SimpleStorageServiceHealthCheckTests.cs
@@ -11,12 +11,12 @@ using NetEvolve.HealthChecks.Tests.Integration.AWS;
 
 [TestGroup($"{nameof(AWS)}.{nameof(S3)}")]
 [TestGroup("Z01TestGroup")]
-[ClassDataSource<LocalStackInstance>(Shared = SharedType.PerClass)]
+[ClassDataSource<FlociStackInstance>(Shared = SharedType.PerClass)]
 public class SimpleStorageServiceHealthCheckTests : HealthCheckTestBase
 {
-    private readonly LocalStackInstance _instance;
+    private readonly FlociStackInstance _instance;
 
-    public SimpleStorageServiceHealthCheckTests(LocalStackInstance instance) => _instance = instance;
+    public SimpleStorageServiceHealthCheckTests(FlociStackInstance instance) => _instance = instance;
 
     [Test]
     public async Task AddAWSS3_UseOptionsCreate_Healthy() =>
@@ -27,10 +27,10 @@ public class SimpleStorageServiceHealthCheckTests : HealthCheckTestBase
                     "TestContainerHealthy",
                     options =>
                     {
-                        options.AccessKey = LocalStackInstance.AccessKey;
-                        options.SecretKey = LocalStackInstance.SecretKey;
+                        options.AccessKey = FlociStackInstance.AccessKey;
+                        options.SecretKey = FlociStackInstance.SecretKey;
                         options.ServiceUrl = _instance.ConnectionString;
-                        options.BucketName = LocalStackInstance.BucketName;
+                        options.BucketName = FlociStackInstance.BucketName;
                         options.Mode = CreationMode.BasicAuthentication;
                         options.Timeout = 10000; // Set a reasonable timeout
                     }
@@ -48,8 +48,8 @@ public class SimpleStorageServiceHealthCheckTests : HealthCheckTestBase
                     "TestContainerUnhealthy",
                     options =>
                     {
-                        options.AccessKey = LocalStackInstance.AccessKey;
-                        options.SecretKey = LocalStackInstance.SecretKey;
+                        options.AccessKey = FlociStackInstance.AccessKey;
+                        options.SecretKey = FlociStackInstance.SecretKey;
                         options.ServiceUrl = _instance.ConnectionString;
                         options.BucketName = "invalid-bucket";
                         options.Mode = CreationMode.BasicAuthentication;
@@ -68,10 +68,10 @@ public class SimpleStorageServiceHealthCheckTests : HealthCheckTestBase
                     "TestContainerDegraded",
                     options =>
                     {
-                        options.AccessKey = LocalStackInstance.AccessKey;
-                        options.SecretKey = LocalStackInstance.SecretKey;
+                        options.AccessKey = FlociStackInstance.AccessKey;
+                        options.SecretKey = FlociStackInstance.SecretKey;
                         options.ServiceUrl = _instance.ConnectionString;
-                        options.BucketName = LocalStackInstance.BucketName;
+                        options.BucketName = FlociStackInstance.BucketName;
                         options.Timeout = 0;
                         options.Mode = CreationMode.BasicAuthentication;
                     }
@@ -91,10 +91,10 @@ public class SimpleStorageServiceHealthCheckTests : HealthCheckTestBase
             {
                 var values = new Dictionary<string, string?>(StringComparer.Ordinal)
                 {
-                    ["HealthChecks:AWSS3:TestContainerHealthy:AccessKey"] = LocalStackInstance.AccessKey,
-                    ["HealthChecks:AWSS3:TestContainerHealthy:SecretKey"] = LocalStackInstance.SecretKey,
+                    ["HealthChecks:AWSS3:TestContainerHealthy:AccessKey"] = FlociStackInstance.AccessKey,
+                    ["HealthChecks:AWSS3:TestContainerHealthy:SecretKey"] = FlociStackInstance.SecretKey,
                     ["HealthChecks:AWSS3:TestContainerHealthy:ServiceUrl"] = _instance.ConnectionString,
-                    ["HealthChecks:AWSS3:TestContainerHealthy:BucketName"] = LocalStackInstance.BucketName,
+                    ["HealthChecks:AWSS3:TestContainerHealthy:BucketName"] = FlociStackInstance.BucketName,
                     ["HealthChecks:AWSS3:TestContainerHealthy:Mode"] = "BasicAuthentication",
                     ["HealthChecks:AWSS3:TestContainerHealthy:Timeout"] = "1000",
                 };
@@ -112,10 +112,10 @@ public class SimpleStorageServiceHealthCheckTests : HealthCheckTestBase
             {
                 var values = new Dictionary<string, string?>(StringComparer.Ordinal)
                 {
-                    ["HealthChecks:AWSS3:TestContainerDegraded:AccessKey"] = LocalStackInstance.AccessKey,
-                    ["HealthChecks:AWSS3:TestContainerDegraded:SecretKey"] = LocalStackInstance.SecretKey,
+                    ["HealthChecks:AWSS3:TestContainerDegraded:AccessKey"] = FlociStackInstance.AccessKey,
+                    ["HealthChecks:AWSS3:TestContainerDegraded:SecretKey"] = FlociStackInstance.SecretKey,
                     ["HealthChecks:AWSS3:TestContainerDegraded:ServiceUrl"] = _instance.ConnectionString,
-                    ["HealthChecks:AWSS3:TestContainerDegraded:BucketName"] = LocalStackInstance.BucketName,
+                    ["HealthChecks:AWSS3:TestContainerDegraded:BucketName"] = FlociStackInstance.BucketName,
                     ["HealthChecks:AWSS3:TestContainerDegraded:Mode"] = "BasicAuthentication",
                     ["HealthChecks:AWSS3:TestContainerDegraded:Timeout"] = "0",
                 };
@@ -133,8 +133,8 @@ public class SimpleStorageServiceHealthCheckTests : HealthCheckTestBase
             {
                 var values = new Dictionary<string, string?>(StringComparer.Ordinal)
                 {
-                    ["HealthChecks:AWSS3:TestContainerUnhealthy:AccessKey"] = LocalStackInstance.AccessKey,
-                    ["HealthChecks:AWSS3:TestContainerUnhealthy:SecretKey"] = LocalStackInstance.SecretKey,
+                    ["HealthChecks:AWSS3:TestContainerUnhealthy:AccessKey"] = FlociStackInstance.AccessKey,
+                    ["HealthChecks:AWSS3:TestContainerUnhealthy:SecretKey"] = FlociStackInstance.SecretKey,
                     ["HealthChecks:AWSS3:TestContainerUnhealthy:ServiceUrl"] = _instance.ConnectionString,
                     ["HealthChecks:AWSS3:TestContainerUnhealthy:BucketName"] = "invalid-bucket",
                     ["HealthChecks:AWSS3:TestContainerUnhealthy:Mode"] = "BasicAuthentication",
@@ -155,10 +155,10 @@ public class SimpleStorageServiceHealthCheckTests : HealthCheckTestBase
             {
                 var values = new Dictionary<string, string?>(StringComparer.Ordinal)
                 {
-                    ["HealthChecks:AWSS3:TestContainerWithTags:AccessKey"] = LocalStackInstance.AccessKey,
-                    ["HealthChecks:AWSS3:TestContainerWithTags:SecretKey"] = LocalStackInstance.SecretKey,
+                    ["HealthChecks:AWSS3:TestContainerWithTags:AccessKey"] = FlociStackInstance.AccessKey,
+                    ["HealthChecks:AWSS3:TestContainerWithTags:SecretKey"] = FlociStackInstance.SecretKey,
                     ["HealthChecks:AWSS3:TestContainerWithTags:ServiceUrl"] = _instance.ConnectionString,
-                    ["HealthChecks:AWSS3:TestContainerWithTags:BucketName"] = LocalStackInstance.BucketName,
+                    ["HealthChecks:AWSS3:TestContainerWithTags:BucketName"] = FlociStackInstance.BucketName,
                     ["HealthChecks:AWSS3:TestContainerWithTags:Mode"] = "BasicAuthentication",
                     ["HealthChecks:AWSS3:TestContainerWithTags:Timeout"] = "1000",
                 };

--- a/tests/NetEvolve.HealthChecks.Tests.Integration/AWS.SNS/SimpleNotificationServiceHealthCheckTests.cs
+++ b/tests/NetEvolve.HealthChecks.Tests.Integration/AWS.SNS/SimpleNotificationServiceHealthCheckTests.cs
@@ -10,12 +10,12 @@ using NetEvolve.HealthChecks.AWS.SNS;
 
 [TestGroup($"{nameof(AWS)}.{nameof(SNS)}")]
 [TestGroup("Z01TestGroup")]
-[ClassDataSource<LocalStackInstance>(Shared = SharedType.PerClass)]
+[ClassDataSource<FlociStackInstance>(Shared = SharedType.PerClass)]
 public class SimpleNotificationServiceHealthCheckTests : HealthCheckTestBase
 {
-    private readonly LocalStackInstance _instance;
+    private readonly FlociStackInstance _instance;
 
-    public SimpleNotificationServiceHealthCheckTests(LocalStackInstance instance) => _instance = instance;
+    public SimpleNotificationServiceHealthCheckTests(FlociStackInstance instance) => _instance = instance;
 
     [Test]
     public async Task AddSimpleNotificationService_UseOptionsCreate_Healthy() =>
@@ -26,10 +26,10 @@ public class SimpleNotificationServiceHealthCheckTests : HealthCheckTestBase
                     "TestContainerHealthy",
                     options =>
                     {
-                        options.AccessKey = LocalStackInstance.AccessKey;
-                        options.SecretKey = LocalStackInstance.SecretKey;
+                        options.AccessKey = FlociStackInstance.AccessKey;
+                        options.SecretKey = FlociStackInstance.SecretKey;
                         options.ServiceUrl = _instance.ConnectionString;
-                        options.TopicName = LocalStackInstance.TopicName;
+                        options.TopicName = FlociStackInstance.TopicName;
                         options.Subscription = _instance.Subscription;
                         options.Mode = CreationMode.BasicAuthentication;
                         options.Timeout = 10000; // Set a reasonable timeout
@@ -48,10 +48,10 @@ public class SimpleNotificationServiceHealthCheckTests : HealthCheckTestBase
                     "TestContainerUnhealthy",
                     options =>
                     {
-                        options.AccessKey = LocalStackInstance.AccessKey;
-                        options.SecretKey = LocalStackInstance.SecretKey;
+                        options.AccessKey = FlociStackInstance.AccessKey;
+                        options.SecretKey = FlociStackInstance.SecretKey;
                         options.ServiceUrl = _instance.ConnectionString;
-                        options.TopicName = LocalStackInstance.TopicName;
+                        options.TopicName = FlociStackInstance.TopicName;
                         options.Subscription = "NotFound";
                         options.Mode = CreationMode.BasicAuthentication;
                     }
@@ -69,8 +69,8 @@ public class SimpleNotificationServiceHealthCheckTests : HealthCheckTestBase
                     "TestContainerUnhealthy",
                     options =>
                     {
-                        options.AccessKey = LocalStackInstance.AccessKey;
-                        options.SecretKey = LocalStackInstance.SecretKey;
+                        options.AccessKey = FlociStackInstance.AccessKey;
+                        options.SecretKey = FlociStackInstance.SecretKey;
                         options.ServiceUrl = _instance.ConnectionString;
                         options.TopicName = "Invalid";
                         options.Subscription = _instance.Subscription;
@@ -90,10 +90,10 @@ public class SimpleNotificationServiceHealthCheckTests : HealthCheckTestBase
                     "TestContainerDegraded",
                     options =>
                     {
-                        options.AccessKey = LocalStackInstance.AccessKey;
-                        options.SecretKey = LocalStackInstance.SecretKey;
+                        options.AccessKey = FlociStackInstance.AccessKey;
+                        options.SecretKey = FlociStackInstance.SecretKey;
                         options.ServiceUrl = _instance.ConnectionString;
-                        options.TopicName = LocalStackInstance.TopicName;
+                        options.TopicName = FlociStackInstance.TopicName;
                         options.Subscription = _instance.Subscription;
                         options.Timeout = 0;
                         options.Mode = CreationMode.BasicAuthentication;
@@ -116,8 +116,8 @@ public class SimpleNotificationServiceHealthCheckTests : HealthCheckTestBase
                     "TestContainerHealthy",
                     options =>
                     {
-                        options.AccessKey = LocalStackInstance.AccessKey;
-                        options.SecretKey = LocalStackInstance.SecretKey;
+                        options.AccessKey = FlociStackInstance.AccessKey;
+                        options.SecretKey = FlociStackInstance.SecretKey;
                         options.ServiceUrl = _instance.ConnectionString;
                         options.TopicName = topicName;
                         options.Subscription = subcription.SubscriptionArn;
@@ -141,10 +141,10 @@ public class SimpleNotificationServiceHealthCheckTests : HealthCheckTestBase
             {
                 var values = new Dictionary<string, string?>(StringComparer.Ordinal)
                 {
-                    { "HealthChecks:AWSSNS:TestContainerHealthy:AccessKey", LocalStackInstance.AccessKey },
-                    { "HealthChecks:AWSSNS:TestContainerHealthy:SecretKey", LocalStackInstance.SecretKey },
+                    { "HealthChecks:AWSSNS:TestContainerHealthy:AccessKey", FlociStackInstance.AccessKey },
+                    { "HealthChecks:AWSSNS:TestContainerHealthy:SecretKey", FlociStackInstance.SecretKey },
                     { "HealthChecks:AWSSNS:TestContainerHealthy:ServiceUrl", _instance.ConnectionString },
-                    { "HealthChecks:AWSSNS:TestContainerHealthy:TopicName", LocalStackInstance.TopicName },
+                    { "HealthChecks:AWSSNS:TestContainerHealthy:TopicName", FlociStackInstance.TopicName },
                     { "HealthChecks:AWSSNS:TestContainerHealthy:Subscription", _instance.Subscription },
                     { "HealthChecks:AWSSNS:TestContainerHealthy:Mode", nameof(CreationMode.BasicAuthentication) },
                     { "HealthChecks:AWSSNS:TestContainerHealthy:Timeout", "10000" },
@@ -162,10 +162,10 @@ public class SimpleNotificationServiceHealthCheckTests : HealthCheckTestBase
             {
                 var values = new Dictionary<string, string?>(StringComparer.Ordinal)
                 {
-                    { "HealthChecks:AWSSNS:TestContainerUnhealthy:AccessKey", LocalStackInstance.AccessKey },
-                    { "HealthChecks:AWSSNS:TestContainerUnhealthy:SecretKey", LocalStackInstance.SecretKey },
+                    { "HealthChecks:AWSSNS:TestContainerUnhealthy:AccessKey", FlociStackInstance.AccessKey },
+                    { "HealthChecks:AWSSNS:TestContainerUnhealthy:SecretKey", FlociStackInstance.SecretKey },
                     { "HealthChecks:AWSSNS:TestContainerUnhealthy:ServiceUrl", _instance.ConnectionString },
-                    { "HealthChecks:AWSSNS:TestContainerUnhealthy:TopicName", LocalStackInstance.TopicName },
+                    { "HealthChecks:AWSSNS:TestContainerUnhealthy:TopicName", FlociStackInstance.TopicName },
                     { "HealthChecks:AWSSNS:TestContainerUnhealthy:Subscription", "NotFound" },
                     { "HealthChecks:AWSSNS:TestContainerUnhealthy:Mode", nameof(CreationMode.BasicAuthentication) },
                 };
@@ -182,8 +182,8 @@ public class SimpleNotificationServiceHealthCheckTests : HealthCheckTestBase
             {
                 var values = new Dictionary<string, string?>(StringComparer.Ordinal)
                 {
-                    { "HealthChecks:AWSSNS:TestContainerUnhealthy:AccessKey", LocalStackInstance.AccessKey },
-                    { "HealthChecks:AWSSNS:TestContainerUnhealthy:SecretKey", LocalStackInstance.SecretKey },
+                    { "HealthChecks:AWSSNS:TestContainerUnhealthy:AccessKey", FlociStackInstance.AccessKey },
+                    { "HealthChecks:AWSSNS:TestContainerUnhealthy:SecretKey", FlociStackInstance.SecretKey },
                     { "HealthChecks:AWSSNS:TestContainerUnhealthy:ServiceUrl", _instance.ConnectionString },
                     { "HealthChecks:AWSSNS:TestContainerUnhealthy:TopicName", "Invalid" },
                     { "HealthChecks:AWSSNS:TestContainerUnhealthy:Subscription", _instance.Subscription },
@@ -202,10 +202,10 @@ public class SimpleNotificationServiceHealthCheckTests : HealthCheckTestBase
             {
                 var values = new Dictionary<string, string?>(StringComparer.Ordinal)
                 {
-                    { "HealthChecks:AWSSNS:TestContainerDegraded:AccessKey", LocalStackInstance.AccessKey },
-                    { "HealthChecks:AWSSNS:TestContainerDegraded:SecretKey", LocalStackInstance.SecretKey },
+                    { "HealthChecks:AWSSNS:TestContainerDegraded:AccessKey", FlociStackInstance.AccessKey },
+                    { "HealthChecks:AWSSNS:TestContainerDegraded:SecretKey", FlociStackInstance.SecretKey },
                     { "HealthChecks:AWSSNS:TestContainerDegraded:ServiceUrl", _instance.ConnectionString },
-                    { "HealthChecks:AWSSNS:TestContainerDegraded:TopicName", LocalStackInstance.TopicName },
+                    { "HealthChecks:AWSSNS:TestContainerDegraded:TopicName", FlociStackInstance.TopicName },
                     { "HealthChecks:AWSSNS:TestContainerDegraded:Subscription", _instance.Subscription },
                     { "HealthChecks:AWSSNS:TestContainerDegraded:Timeout", "0" },
                     { "HealthChecks:AWSSNS:TestContainerDegraded:Mode", nameof(CreationMode.BasicAuthentication) },
@@ -227,8 +227,8 @@ public class SimpleNotificationServiceHealthCheckTests : HealthCheckTestBase
                 {
                     var values = new Dictionary<string, string?>(StringComparer.Ordinal)
                     {
-                        { "HealthChecks:AWSSNS:TestContainerHealthy:AccessKey", LocalStackInstance.AccessKey },
-                        { "HealthChecks:AWSSNS:TestContainerHealthy:SecretKey", LocalStackInstance.SecretKey },
+                        { "HealthChecks:AWSSNS:TestContainerHealthy:AccessKey", FlociStackInstance.AccessKey },
+                        { "HealthChecks:AWSSNS:TestContainerHealthy:SecretKey", FlociStackInstance.SecretKey },
                         { "HealthChecks:AWSSNS:TestContainerHealthy:ServiceUrl", _instance.ConnectionString },
                         { "HealthChecks:AWSSNS:TestContainerHealthy:TopicName", topicName },
                         { "HealthChecks:AWSSNS:TestContainerHealthy:Subscription", subscription.SubscriptionArn },

--- a/tests/NetEvolve.HealthChecks.Tests.Integration/AWS.SQS/SimpleQueueServiceHealthCheckTests.cs
+++ b/tests/NetEvolve.HealthChecks.Tests.Integration/AWS.SQS/SimpleQueueServiceHealthCheckTests.cs
@@ -10,12 +10,12 @@ using NetEvolve.HealthChecks.AWS.SQS;
 
 [TestGroup($"{nameof(AWS)}.{nameof(SQS)}")]
 [TestGroup("Z01TestGroup")]
-[ClassDataSource<LocalStackInstance>(Shared = SharedType.PerClass)]
+[ClassDataSource<FlociStackInstance>(Shared = SharedType.PerClass)]
 public class SimpleQueueServiceHealthCheckTests : HealthCheckTestBase
 {
-    private readonly LocalStackInstance _instance;
+    private readonly FlociStackInstance _instance;
 
-    public SimpleQueueServiceHealthCheckTests(LocalStackInstance instance) => _instance = instance;
+    public SimpleQueueServiceHealthCheckTests(FlociStackInstance instance) => _instance = instance;
 
     [Test]
     public async Task AddAWSSQS_UseOptionsCreate_Healthy() =>
@@ -26,10 +26,10 @@ public class SimpleQueueServiceHealthCheckTests : HealthCheckTestBase
                     "TestContainerHealthy",
                     options =>
                     {
-                        options.AccessKey = LocalStackInstance.AccessKey;
-                        options.SecretKey = LocalStackInstance.SecretKey;
+                        options.AccessKey = FlociStackInstance.AccessKey;
+                        options.SecretKey = FlociStackInstance.SecretKey;
                         options.ServiceUrl = _instance.ConnectionString;
-                        options.QueueName = LocalStackInstance.QueueName;
+                        options.QueueName = FlociStackInstance.QueueName;
                         options.Mode = CreationMode.BasicAuthentication;
                         options.Timeout = 10000; // Set a reasonable timeout
                     }
@@ -47,8 +47,8 @@ public class SimpleQueueServiceHealthCheckTests : HealthCheckTestBase
                     "TestContainerUnhealthy",
                     options =>
                     {
-                        options.AccessKey = LocalStackInstance.AccessKey;
-                        options.SecretKey = LocalStackInstance.SecretKey;
+                        options.AccessKey = FlociStackInstance.AccessKey;
+                        options.SecretKey = FlociStackInstance.SecretKey;
                         options.ServiceUrl = _instance.ConnectionString;
                         options.QueueName = "invalid";
                         options.Mode = CreationMode.BasicAuthentication;
@@ -67,10 +67,10 @@ public class SimpleQueueServiceHealthCheckTests : HealthCheckTestBase
                     "TestContainerDegraded",
                     options =>
                     {
-                        options.AccessKey = LocalStackInstance.AccessKey;
-                        options.SecretKey = LocalStackInstance.SecretKey;
+                        options.AccessKey = FlociStackInstance.AccessKey;
+                        options.SecretKey = FlociStackInstance.SecretKey;
                         options.ServiceUrl = _instance.ConnectionString;
-                        options.QueueName = LocalStackInstance.QueueName;
+                        options.QueueName = FlociStackInstance.QueueName;
                         options.Timeout = 0;
                         options.Mode = CreationMode.BasicAuthentication;
                     }
@@ -90,10 +90,10 @@ public class SimpleQueueServiceHealthCheckTests : HealthCheckTestBase
             {
                 var values = new Dictionary<string, string?>(StringComparer.Ordinal)
                 {
-                    { "HealthChecks:AWSSQS:TestContainerHealthy:AccessKey", LocalStackInstance.AccessKey },
-                    { "HealthChecks:AWSSQS:TestContainerHealthy:SecretKey", LocalStackInstance.SecretKey },
+                    { "HealthChecks:AWSSQS:TestContainerHealthy:AccessKey", FlociStackInstance.AccessKey },
+                    { "HealthChecks:AWSSQS:TestContainerHealthy:SecretKey", FlociStackInstance.SecretKey },
                     { "HealthChecks:AWSSQS:TestContainerHealthy:ServiceUrl", _instance.ConnectionString },
-                    { "HealthChecks:AWSSQS:TestContainerHealthy:QueueName", LocalStackInstance.QueueName },
+                    { "HealthChecks:AWSSQS:TestContainerHealthy:QueueName", FlociStackInstance.QueueName },
                     { "HealthChecks:AWSSQS:TestContainerHealthy:Mode", nameof(CreationMode.BasicAuthentication) },
                     { "HealthChecks:AWSSQS:TestContainerHealthy:Timeout", "10000" },
                 };
@@ -110,8 +110,8 @@ public class SimpleQueueServiceHealthCheckTests : HealthCheckTestBase
             {
                 var values = new Dictionary<string, string?>(StringComparer.Ordinal)
                 {
-                    { "HealthChecks:AWSSQS:TestContainerUnhealthy:AccessKey", LocalStackInstance.AccessKey },
-                    { "HealthChecks:AWSSQS:TestContainerUnhealthy:SecretKey", LocalStackInstance.SecretKey },
+                    { "HealthChecks:AWSSQS:TestContainerUnhealthy:AccessKey", FlociStackInstance.AccessKey },
+                    { "HealthChecks:AWSSQS:TestContainerUnhealthy:SecretKey", FlociStackInstance.SecretKey },
                     { "HealthChecks:AWSSQS:TestContainerUnhealthy:ServiceUrl", _instance.ConnectionString },
                     { "HealthChecks:AWSSQS:TestContainerUnhealthy:QueueName", "invalid" },
                     { "HealthChecks:AWSSQS:TestContainerUnhealthy:Mode", nameof(CreationMode.BasicAuthentication) },
@@ -129,10 +129,10 @@ public class SimpleQueueServiceHealthCheckTests : HealthCheckTestBase
             {
                 var values = new Dictionary<string, string?>(StringComparer.Ordinal)
                 {
-                    { "HealthChecks:AWSSQS:TestContainerDegraded:AccessKey", LocalStackInstance.AccessKey },
-                    { "HealthChecks:AWSSQS:TestContainerDegraded:SecretKey", LocalStackInstance.SecretKey },
+                    { "HealthChecks:AWSSQS:TestContainerDegraded:AccessKey", FlociStackInstance.AccessKey },
+                    { "HealthChecks:AWSSQS:TestContainerDegraded:SecretKey", FlociStackInstance.SecretKey },
                     { "HealthChecks:AWSSQS:TestContainerDegraded:ServiceUrl", _instance.ConnectionString },
-                    { "HealthChecks:AWSSQS:TestContainerDegraded:QueueName", LocalStackInstance.QueueName },
+                    { "HealthChecks:AWSSQS:TestContainerDegraded:QueueName", FlociStackInstance.QueueName },
                     { "HealthChecks:AWSSQS:TestContainerDegraded:Timeout", "0" },
                     { "HealthChecks:AWSSQS:TestContainerDegraded:Mode", nameof(CreationMode.BasicAuthentication) },
                 };

--- a/tests/NetEvolve.HealthChecks.Tests.Integration/AWS/FlociStackInstance.cs
+++ b/tests/NetEvolve.HealthChecks.Tests.Integration/AWS/FlociStackInstance.cs
@@ -10,22 +10,22 @@ using Amazon.S3.Model;
 using Amazon.SimpleNotificationService;
 using Amazon.SQS;
 using Microsoft.Extensions.Logging.Abstractions;
-using Testcontainers.LocalStack;
-using TestContainer = Testcontainers.LocalStack.LocalStackContainer;
+using Testcontainers.Floci;
+using TestContainer = Testcontainers.Floci.FlociContainer;
 
-public sealed class LocalStackInstance : IAsyncInitializer, IAsyncDisposable
+public sealed class FlociStackInstance : IAsyncInitializer, IAsyncDisposable
 {
     /// <summary>Access Key</summary>
     /// <see href="https://docs.aws.amazon.com/STS/latest/APIReference/API_GetAccessKeyInfo.html" />
-    internal const string AccessKey = "AKIAIOSFODNN7EXAMPLE";
-    internal const string SecretKey = "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY";
+    internal const string AccessKey = FlociBuilder.AccessKey;
+    internal const string SecretKey = FlociBuilder.SecretKey;
     internal const string BucketName = "test-bucket";
     internal const string TopicName = "test-topic";
     internal const string QueueName = "test-queue";
     internal const string TableName = "test-table";
 
-    private readonly TestContainer _container = new LocalStackBuilder(
-        /*dockerimage*/"localstack/localstack:4.14.0"
+    private readonly TestContainer _container = new FlociBuilder(
+        /*dockerimage*/"floci/floci:1.5.17"
     )
         .WithLogger(NullLogger.Instance)
         .WithEnvironment("AWS_ACCESS_KEY_ID", AccessKey)
@@ -135,25 +135,32 @@ public sealed class LocalStackInstance : IAsyncInitializer, IAsyncDisposable
         }
     }
 
+    internal async Task CreateEC2InstanceAsync(CancellationToken cancellationToken = default)
+    {
+        using var ec2Client = new AmazonEC2Client(
+            AccessKey,
+            SecretKey,
+            new AmazonEC2Config { ServiceURL = ConnectionString }
+        );
+
+        // Ensure the key pair exists
+        try
+        {
+            _ = await ec2Client
+                .CreateKeyPairAsync(new CreateKeyPairRequest { KeyName = "development" }, cancellationToken)
+                .ConfigureAwait(false);
+        }
+        catch
+        {
+            // Key pair may already exist; ignore
+        }
+    }
+
     private async Task CreateEC2DEfaults(CancellationToken cancellationToken)
     {
         try
         {
-            // Create EC2 Defaults if needed
-            using var ec2Client = new AmazonEC2Client(
-                AccessKey,
-                SecretKey,
-                new AmazonEC2Config { ServiceURL = ConnectionString }
-            );
-
-            var request = new RunInstancesRequest()
-            {
-                InstanceType = InstanceType.T1Micro,
-                MinCount = 1,
-                MaxCount = 1,
-                KeyName = "development",
-            };
-            _ = await ec2Client.RunInstancesAsync(request, cancellationToken).ConfigureAwait(false);
+            await CreateEC2InstanceAsync(cancellationToken).ConfigureAwait(false);
         }
         catch
         {

--- a/tests/NetEvolve.HealthChecks.Tests.Integration/Firebird/FirebirdDatabase.cs
+++ b/tests/NetEvolve.HealthChecks.Tests.Integration/Firebird/FirebirdDatabase.cs
@@ -20,18 +20,16 @@ public sealed class FirebirdDatabase : IAsyncInitializer, IAsyncDisposable
 
     public async Task InitializeAsync()
     {
-        Environment.SetEnvironmentVariable(
-            "USERNAME",
-            ToAsciiUsername(),
-            EnvironmentVariableTarget.Process
-        );
+        Environment.SetEnvironmentVariable("USERNAME", ToAsciiUsername(), EnvironmentVariableTarget.Process);
         await _database.StartAsync().ConfigureAwait(false);
     }
 
     private static string ToAsciiUsername()
     {
         // Normalisierung: zerlegt "ü" in "u" + Combining Diaeresis
-        var normalized = Environment.UserName.Replace("ß", "ss", StringComparison.Ordinal).Normalize(NormalizationForm.FormD);
+        var normalized = Environment
+            .UserName.Replace("ß", "ss", StringComparison.Ordinal)
+            .Normalize(NormalizationForm.FormD);
 
         var sb = new StringBuilder();
         foreach (var c in normalized)

--- a/tests/NetEvolve.HealthChecks.Tests.Integration/Firebird/FirebirdDatabase.cs
+++ b/tests/NetEvolve.HealthChecks.Tests.Integration/Firebird/FirebirdDatabase.cs
@@ -1,5 +1,7 @@
 ﻿namespace NetEvolve.HealthChecks.Tests.Integration.Firebird;
 
+using System.Globalization;
+using System.Text;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging.Abstractions;
 using Testcontainers.FirebirdSql;
@@ -16,5 +18,32 @@ public sealed class FirebirdDatabase : IAsyncInitializer, IAsyncDisposable
 
     public async ValueTask DisposeAsync() => await _database.DisposeAsync().ConfigureAwait(false);
 
-    public async Task InitializeAsync() => await _database.StartAsync().ConfigureAwait(false);
+    public async Task InitializeAsync()
+    {
+        Environment.SetEnvironmentVariable(
+            "USERNAME",
+            ToAsciiUsername(),
+            EnvironmentVariableTarget.Process
+        );
+        await _database.StartAsync().ConfigureAwait(false);
+    }
+
+    private static string ToAsciiUsername()
+    {
+        // Normalisierung: zerlegt "ü" in "u" + Combining Diaeresis
+        var normalized = Environment.UserName.Replace("ß", "ss", StringComparison.Ordinal).Normalize(NormalizationForm.FormD);
+
+        var sb = new StringBuilder();
+        foreach (var c in normalized)
+        {
+            // Nur Basis-Buchstaben behalten, Combining-Zeichen (Umlaute etc.) weglassen
+            if (CharUnicodeInfo.GetUnicodeCategory(c) != UnicodeCategory.NonSpacingMark)
+            {
+                _ = sb.Append(c);
+            }
+        }
+
+        return sb.ToString().Normalize(NormalizationForm.FormC);
+        // ü → u, ö → o, ä → a, ß bleibt ß (kein Basisbuchstabe)
+    }
 }

--- a/tests/NetEvolve.HealthChecks.Tests.Integration/NetEvolve.HealthChecks.Tests.Integration.csproj
+++ b/tests/NetEvolve.HealthChecks.Tests.Integration/NetEvolve.HealthChecks.Tests.Integration.csproj
@@ -111,7 +111,7 @@
     <PackageReference Include="Testcontainers.Keycloak" />
     <PackageReference Include="Testcontainers.KurrentDb" />
     <PackageReference Include="Testcontainers.Kusto" />
-    <PackageReference Include="Testcontainers.LocalStack" />
+    <PackageReference Include="Testcontainers.Floci" />
     <PackageReference Include="Testcontainers.MariaDb" />
     <PackageReference Include="Testcontainers.Milvus" />
     <PackageReference Include="Testcontainers.Minio" />

--- a/tests/NetEvolve.HealthChecks.Tests.Integration/_snapshots/DynamoDbHealthCheck.AddAWSDynamoDB_UseConfiguration_WhenTableInvalid_Unhealthy.verified.txt
+++ b/tests/NetEvolve.HealthChecks.Tests.Integration/_snapshots/DynamoDbHealthCheck.AddAWSDynamoDB_UseConfiguration_WhenTableInvalid_Unhealthy.verified.txt
@@ -9,7 +9,7 @@
             type: HttpErrorResponseException
           }
         ],
-        message: Cannot do operations on a non-existent table,
+        message: Requested resource not found,
         type: Amazon.DynamoDBv2.Model.ResourceNotFoundException
       },
       name: TestContainerUnhealthy,

--- a/tests/NetEvolve.HealthChecks.Tests.Integration/_snapshots/DynamoDbHealthCheck.AddAWSDynamoDB_UseOptionsCreate_WhenTableInvalid_Unhealthy.verified.txt
+++ b/tests/NetEvolve.HealthChecks.Tests.Integration/_snapshots/DynamoDbHealthCheck.AddAWSDynamoDB_UseOptionsCreate_WhenTableInvalid_Unhealthy.verified.txt
@@ -9,7 +9,7 @@
             type: HttpErrorResponseException
           }
         ],
-        message: Cannot do operations on a non-existent table,
+        message: Requested resource not found,
         type: Amazon.DynamoDBv2.Model.ResourceNotFoundException
       },
       name: TestContainerUnhealthy,

--- a/tests/NetEvolve.HealthChecks.Tests.Integration/_snapshots/SimpleQueueServiceHealthCheck.AddAWSSQS_UseConfiguration_WhenQueueInvalid_Unhealthy.verified.txt
+++ b/tests/NetEvolve.HealthChecks.Tests.Integration/_snapshots/SimpleQueueServiceHealthCheck.AddAWSSQS_UseConfiguration_WhenQueueInvalid_Unhealthy.verified.txt
@@ -9,7 +9,7 @@
             type: HttpErrorResponseException
           }
         ],
-        message: The specified queue does not exist.,
+        message: The specified queue does not exist for this wsdl version.,
         type: Amazon.SQS.Model.QueueDoesNotExistException
       },
       name: TestContainerUnhealthy,

--- a/tests/NetEvolve.HealthChecks.Tests.Integration/_snapshots/SimpleQueueServiceHealthCheck.AddAWSSQS_UseOptionsCreate_WhenQueueInvalid_Unhealthy.verified.txt
+++ b/tests/NetEvolve.HealthChecks.Tests.Integration/_snapshots/SimpleQueueServiceHealthCheck.AddAWSSQS_UseOptionsCreate_WhenQueueInvalid_Unhealthy.verified.txt
@@ -9,7 +9,7 @@
             type: HttpErrorResponseException
           }
         ],
-        message: The specified queue does not exist.,
+        message: The specified queue does not exist for this wsdl version.,
         type: Amazon.SQS.Model.QueueDoesNotExistException
       },
       name: TestContainerUnhealthy,

--- a/tests/NetEvolve.HealthChecks.Tests.Integration/_snapshots/SimpleStorageServiceHealthCheck.AddAWSS3_UseConfiguration_WhenBucketInvalid_Unhealthy.verified.txt
+++ b/tests/NetEvolve.HealthChecks.Tests.Integration/_snapshots/SimpleStorageServiceHealthCheck.AddAWSS3_UseConfiguration_WhenBucketInvalid_Unhealthy.verified.txt
@@ -9,7 +9,7 @@
             type: HttpErrorResponseException
           }
         ],
-        message: The specified bucket does not exist,
+        message: The specified bucket does not exist.,
         type: Amazon.S3.Model.NoSuchBucketException
       },
       name: TestContainerUnhealthy,

--- a/tests/NetEvolve.HealthChecks.Tests.Integration/_snapshots/SimpleStorageServiceHealthCheck.AddAWSS3_UseOptionsCreate_WhenBucketInvalid_Unhealthy.verified.txt
+++ b/tests/NetEvolve.HealthChecks.Tests.Integration/_snapshots/SimpleStorageServiceHealthCheck.AddAWSS3_UseOptionsCreate_WhenBucketInvalid_Unhealthy.verified.txt
@@ -9,7 +9,7 @@
             type: HttpErrorResponseException
           }
         ],
-        message: The specified bucket does not exist,
+        message: The specified bucket does not exist.,
         type: Amazon.S3.Model.NoSuchBucketException
       },
       name: TestContainerUnhealthy,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * EC2 health check now verifies key-pair existence and fixes generated-source indentation to prevent formatting/compilation issues.

* **Tests**
  * Integration tests and fixtures migrated to the new local AWS stack provider; EC2 setup improved and snapshots refreshed for consistent results.

* **Chores**
  * Test infrastructure dependencies and initialization flows updated for consistency and reliability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dailydevops/healthchecks/pull/1848?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->