### PR TITLE
fix(build): suppress unfixed SQLitePCLRaw NU1903 audit error

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -23,4 +23,7 @@
   <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" Condition=" '$(TargetFramework)' != 'netstandard2.0' " />
   </ItemGroup>
+  <ItemGroup Label="No fixed version available yet, see https://github.com/advisories/GHSA-2m69-gcr7-jv3q">
+    <NuGetAuditSuppress Include="https://github.com/advisories/GHSA-2m69-gcr7-jv3q" />
+  </ItemGroup>
 </Project>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -23,7 +23,7 @@
   <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" Condition=" '$(TargetFramework)' != 'netstandard2.0' " />
   </ItemGroup>
-  <ItemGroup Label="No fixed version available yet, see https://github.com/advisories/GHSA-2m69-gcr7-jv3q">
+  <ItemGroup Condition=" '$(MSBuildProjectName)' == 'NetEvolve.HealthChecks.SQLite' " Label="Temporary NuGet audit suppression (no fixed version yet): https://github.com/advisories/GHSA-2m69-gcr7-jv3q">
     <NuGetAuditSuppress Include="https://github.com/advisories/GHSA-2m69-gcr7-jv3q" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
## Summary
- CI build fails with `error NU1903` on `SQLitePCLRaw.lib.e_sqlite3` 2.1.11 (GHSA-2m69-gcr7-jv3q, high severity).
- No patched version of this package exists yet.
- Suppresses the specific advisory via `NuGetAuditSuppress` in `Directory.Build.props` until a fix is released.

## Test plan
- [x] `dotnet build src/NetEvolve.HealthChecks.SQLite/NetEvolve.HealthChecks.SQLite.csproj -c Release` succeeds with 0 warnings/errors.
- [ ] CI pipeline passes.