### PR TITLE
fix(build): widen NU1903 suppression to all projects

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -23,7 +23,7 @@
   <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" Condition=" '$(TargetFramework)' != 'netstandard2.0' " />
   </ItemGroup>
-  <ItemGroup Condition=" '$(MSBuildProjectName)' == 'NetEvolve.HealthChecks.SQLite' " Label="Temporary NuGet audit suppression (no fixed version yet): https://github.com/advisories/GHSA-2m69-gcr7-jv3q">
+  <ItemGroup Label="Temporary NuGet audit suppression (no fixed version yet): https://github.com/advisories/GHSA-2m69-gcr7-jv3q">
     <NuGetAuditSuppress Include="https://github.com/advisories/GHSA-2m69-gcr7-jv3q" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
## Summary
- PR #1910 scoped the `NuGetAuditSuppress` for GHSA-2m69-gcr7-jv3q to `NetEvolve.HealthChecks.SQLite` only (narrowed by an automated Copilot autofix commit).
- Test projects (Architecture, Integration, Unit) reference `SQLitePCLRaw.lib.e_sqlite3` transitively too and still failed CI with `NU1903`.
- Removes the project-name condition so the suppression applies repo-wide, matching the original intent (no patched version exists yet).

## Test plan
- [x] `dotnet build tests/NetEvolve.HealthChecks.Tests.Architecture/NetEvolve.HealthChecks.Tests.Architecture.csproj -c Release` succeeds.
- [ ] CI pipeline passes.