### PR TITLE
fix(ci): update dailydevops/pipelines to v2.5.118

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -35,7 +35,7 @@ permissions:
 jobs:
   all:
     name: Build & Tests
-    uses: dailydevops/pipelines/.github/workflows/build-dotnet-dynamic.yml@1acd2ca40debe423847625cdb537f5cee3b14b43 # 2.5.1
+    uses: dailydevops/pipelines/.github/workflows/build-dotnet-dynamic.yml@26223e188aca67bbf86d44b5b2e6d10ed625a31e # 2.5.118
     with:
       dotnetLogging: ${{ inputs.dotnet-logging }}
       dotnetVersion: ${{ vars.NE_DOTNET_TARGETFRAMEWORKS }}


### PR DESCRIPTION
Updates the pinned `dailydevops/pipelines` reusable workflow in `cicd.yml` from 2.5.1 to 2.5.118, aligning it with `publish-nuget.yml` and `mutation.yml`.

Primary motivation: 2.5.1 uses `codecov/codecov-action` v6.0.0, whose CLI wrapper fails GPG signature verification since Codecov rotated its signing key (RSA `27034E7FDB850E0BBC2C62FF806BB28AED779869`, 2026-07-09). With `fail_ci_if_error: true` this fails every test-group job (Z00–Z05) on all PRs and on `main`, even though builds and tests pass. Version 2.5.118 uses `codecov/codecov-action` v7.0.0, which resolves the verification error.