### PR TITLE
chore(ci): use Conventional Commits prefix for Dependabot nuget security updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,20 @@
 
 version: 2
 updates:
+  # Regular NuGet updates are handled by Renovate; this entry exists so that
+  # Dependabot security updates use a Conventional Commits compliant prefix.
+  - package-ecosystem: "nuget"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    commit-message:
+      prefix: "chore(deps)"
+    labels:
+      - "dependency:nuget"
+    open-pull-requests-limit: 0
+    assignees:
+      - samtrion
+
   - package-ecosystem: "devcontainers"
     directory: "/"
     schedule:


### PR DESCRIPTION
Adds a `nuget` package-ecosystem entry to `.github/dependabot.yml` with `open-pull-requests-limit: 0`.

Regular NuGet updates remain handled by Renovate — the limit of 0 prevents Dependabot version-update PRs. However, Dependabot **security** updates (like #1912) only honor `commit-message` settings when the ecosystem is configured. Without this entry, security PRs are created with the default message ("Bump the nuget group with 1 update"), which fails the Commitlint check (`type-empty`/`subject-empty`).

With this change, future security PRs will use the `chore(deps)` prefix and pass Commitlint.