### PR TITLE
fix(GCP.PubSub): pass cancellation token to ReadPageAsync

### DIFF
--- a/src/NetEvolve.HealthChecks.GCP.PubSub/PubSubHealthCheck.cs
+++ b/src/NetEvolve.HealthChecks.GCP.PubSub/PubSubHealthCheck.cs
@@ -32,7 +32,7 @@ internal sealed partial class PubSubHealthCheck
                 async () =>
                 {
                     var result = client.ListTopicsAsync(projectName);
-                    var topics = await result.ReadPageAsync(1).ConfigureAwait(false);
+                    var topics = await result.ReadPageAsync(1, cancellationToken).ConfigureAwait(false);
                     return topics?.GetEnumerator().MoveNext() ?? false;
                 },
                 cancellationToken


### PR DESCRIPTION
## Summary
- Pass the health check's `cancellationToken` to `ReadPageAsync` in `PubSubHealthCheck` instead of relying on the implicit default.
- Fixes a SonarAnalyzer S8949 build error that was blocking CI on PR #1971 (renovate/sonaranalyzer.csharp-10.x).

## Test plan
- [x] `dotnet build src/NetEvolve.HealthChecks.GCP.PubSub/NetEvolve.HealthChecks.GCP.PubSub.csproj -f net10.0` succeeds
- [ ] CI passes across all target frameworks

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FJHw1xA5gdRdy4f31o6LHE