### PR TITLE
Migrate Tests.Unit from NSubstitute to TUnit.Mocks

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -172,6 +172,7 @@
     <PackageVersion Include="Testcontainers.ServiceBus" Version="4.13.0" />
     <PackageVersion Include="TngTech.ArchUnitNET.TUnit" Version="0.13.3" />
     <PackageVersion Include="TUnit" Version="1.61.38" />
+    <PackageVersion Include="TUnit.Mocks" Version="1.61.38" />
     <PackageVersion Include="Verify.TUnit" Version="31.27.0" />
   </ItemGroup>
 </Project>

--- a/tests/NetEvolve.HealthChecks.Tests.Unit/AWS.DynamoDB/DynamoDbHealthCheckTests.cs
+++ b/tests/NetEvolve.HealthChecks.Tests.Unit/AWS.DynamoDB/DynamoDbHealthCheckTests.cs
@@ -7,7 +7,7 @@ using Microsoft.Extensions.Diagnostics.HealthChecks;
 using Microsoft.Extensions.Options;
 using NetEvolve.Extensions.TUnit;
 using NetEvolve.HealthChecks.AWS.DynamoDB;
-using NSubstitute;
+using TUnit.Mocks;
 
 [TestGroup($"{nameof(AWS)}.{nameof(DynamoDB)}")]
 public sealed class DynamoDbHealthCheckTests
@@ -18,8 +18,8 @@ public sealed class DynamoDbHealthCheckTests
     public async Task CheckHealthAsync_WhenContextNull_ThrowArgumentNullException()
     {
         // Arrange
-        var optionsMonitor = Substitute.For<IOptionsMonitor<DynamoDbOptions>>();
-        var serviceProvider = Substitute.For<IServiceProvider>();
+        var optionsMonitor = IOptionsMonitor<DynamoDbOptions>.Mock();
+        var serviceProvider = IServiceProvider.Mock();
         var check = new DynamoDbHealthCheck(serviceProvider, optionsMonitor);
 
         // Act
@@ -33,8 +33,8 @@ public sealed class DynamoDbHealthCheckTests
     public async Task CheckHealthAsync_WhenCancellationTokenIsCancelled_ShouldReturnUnhealthy()
     {
         // Arrange
-        var optionsMonitor = Substitute.For<IOptionsMonitor<DynamoDbOptions>>();
-        var serviceProvider = Substitute.For<IServiceProvider>();
+        var optionsMonitor = IOptionsMonitor<DynamoDbOptions>.Mock();
+        var serviceProvider = IServiceProvider.Mock();
         var check = new DynamoDbHealthCheck(serviceProvider, optionsMonitor);
         var context = new HealthCheckContext
         {
@@ -57,8 +57,8 @@ public sealed class DynamoDbHealthCheckTests
     public async Task CheckHealthAsync_WhenOptionsAreNull_ShouldReturnUnhealthy()
     {
         // Arrange
-        var optionsMonitor = Substitute.For<IOptionsMonitor<DynamoDbOptions>>();
-        var serviceProvider = Substitute.For<IServiceProvider>();
+        var optionsMonitor = IOptionsMonitor<DynamoDbOptions>.Mock();
+        var serviceProvider = IServiceProvider.Mock();
         var check = new DynamoDbHealthCheck(serviceProvider, optionsMonitor);
         var context = new HealthCheckContext
         {

--- a/tests/NetEvolve.HealthChecks.Tests.Unit/AWS.EC2/ElasticComputeCloudHealthCheckTests.cs
+++ b/tests/NetEvolve.HealthChecks.Tests.Unit/AWS.EC2/ElasticComputeCloudHealthCheckTests.cs
@@ -7,7 +7,7 @@ using Microsoft.Extensions.Diagnostics.HealthChecks;
 using Microsoft.Extensions.Options;
 using NetEvolve.Extensions.TUnit;
 using NetEvolve.HealthChecks.AWS.EC2;
-using NSubstitute;
+using TUnit.Mocks;
 
 [TestGroup($"{nameof(AWS)}.{nameof(EC2)}")]
 public sealed class ElasticComputeCloudHealthCheckTests
@@ -18,8 +18,8 @@ public sealed class ElasticComputeCloudHealthCheckTests
     public async Task CheckHealthAsync_WhenContextNull_ThrowArgumentNullException()
     {
         // Arrange
-        var optionsMonitor = Substitute.For<IOptionsMonitor<ElasticComputeCloudOptions>>();
-        var serviceProvider = Substitute.For<IServiceProvider>();
+        var optionsMonitor = IOptionsMonitor<ElasticComputeCloudOptions>.Mock();
+        var serviceProvider = IServiceProvider.Mock();
         var check = new ElasticComputeCloudHealthCheck(serviceProvider, optionsMonitor);
 
         // Act
@@ -33,8 +33,8 @@ public sealed class ElasticComputeCloudHealthCheckTests
     public async Task CheckHealthAsync_WhenCancellationTokenIsCancelled_ShouldReturnUnhealthy()
     {
         // Arrange
-        var optionsMonitor = Substitute.For<IOptionsMonitor<ElasticComputeCloudOptions>>();
-        var serviceProvider = Substitute.For<IServiceProvider>();
+        var optionsMonitor = IOptionsMonitor<ElasticComputeCloudOptions>.Mock();
+        var serviceProvider = IServiceProvider.Mock();
         var check = new ElasticComputeCloudHealthCheck(serviceProvider, optionsMonitor);
         var context = new HealthCheckContext
         {
@@ -57,8 +57,8 @@ public sealed class ElasticComputeCloudHealthCheckTests
     public async Task CheckHealthAsync_WhenOptionsAreNull_ShouldReturnUnhealthy()
     {
         // Arrange
-        var optionsMonitor = Substitute.For<IOptionsMonitor<ElasticComputeCloudOptions>>();
-        var serviceProvider = Substitute.For<IServiceProvider>();
+        var optionsMonitor = IOptionsMonitor<ElasticComputeCloudOptions>.Mock();
+        var serviceProvider = IServiceProvider.Mock();
         var check = new ElasticComputeCloudHealthCheck(serviceProvider, optionsMonitor);
         var context = new HealthCheckContext
         {

--- a/tests/NetEvolve.HealthChecks.Tests.Unit/AWS.S3/SimpleStorageServiceHealthCheckTests.cs
+++ b/tests/NetEvolve.HealthChecks.Tests.Unit/AWS.S3/SimpleStorageServiceHealthCheckTests.cs
@@ -7,7 +7,7 @@ using Microsoft.Extensions.Diagnostics.HealthChecks;
 using Microsoft.Extensions.Options;
 using NetEvolve.Extensions.TUnit;
 using NetEvolve.HealthChecks.AWS.S3;
-using NSubstitute;
+using TUnit.Mocks;
 
 [TestGroup($"{nameof(AWS)}.{nameof(S3)}")]
 public sealed class SimpleStorageServiceHealthCheckTests
@@ -18,8 +18,8 @@ public sealed class SimpleStorageServiceHealthCheckTests
     public async Task CheckHealthAsync_WhenContextNull_ThrowArgumentNullException()
     {
         // Arrange
-        var optionsMonitor = Substitute.For<IOptionsMonitor<SimpleStorageServiceOptions>>();
-        var serviceProvider = Substitute.For<IServiceProvider>();
+        var optionsMonitor = IOptionsMonitor<SimpleStorageServiceOptions>.Mock();
+        var serviceProvider = IServiceProvider.Mock();
         var check = new SimpleStorageServiceHealthCheck(serviceProvider, optionsMonitor);
 
         // Act
@@ -33,8 +33,8 @@ public sealed class SimpleStorageServiceHealthCheckTests
     public async Task CheckHealthAsync_WhenCancellationTokenIsCancelled_ShouldReturnUnhealthy()
     {
         // Arrange
-        var optionsMonitor = Substitute.For<IOptionsMonitor<SimpleStorageServiceOptions>>();
-        var serviceProvider = Substitute.For<IServiceProvider>();
+        var optionsMonitor = IOptionsMonitor<SimpleStorageServiceOptions>.Mock();
+        var serviceProvider = IServiceProvider.Mock();
         var check = new SimpleStorageServiceHealthCheck(serviceProvider, optionsMonitor);
         var context = new HealthCheckContext
         {
@@ -57,8 +57,8 @@ public sealed class SimpleStorageServiceHealthCheckTests
     public async Task CheckHealthAsync_WhenOptionsAreNull_ShouldReturnUnhealthy()
     {
         // Arrange
-        var optionsMonitor = Substitute.For<IOptionsMonitor<SimpleStorageServiceOptions>>();
-        var serviceProvider = Substitute.For<IServiceProvider>();
+        var optionsMonitor = IOptionsMonitor<SimpleStorageServiceOptions>.Mock();
+        var serviceProvider = IServiceProvider.Mock();
         var check = new SimpleStorageServiceHealthCheck(serviceProvider, optionsMonitor);
         var context = new HealthCheckContext
         {

--- a/tests/NetEvolve.HealthChecks.Tests.Unit/Apache.ActiveMq/ActiveMqHealthCheckTests.cs
+++ b/tests/NetEvolve.HealthChecks.Tests.Unit/Apache.ActiveMq/ActiveMqHealthCheckTests.cs
@@ -7,7 +7,7 @@ using Microsoft.Extensions.Diagnostics.HealthChecks;
 using Microsoft.Extensions.Options;
 using NetEvolve.Extensions.TUnit;
 using NetEvolve.HealthChecks.Apache.ActiveMq;
-using NSubstitute;
+using TUnit.Mocks;
 
 [TestGroup($"{nameof(Apache)}.{nameof(ActiveMq)}")]
 public sealed class ActiveMqHealthCheckTests
@@ -18,8 +18,8 @@ public sealed class ActiveMqHealthCheckTests
     public async Task CheckHealthAsync_WhenContextNull_ThrowArgumentNullException()
     {
         // Arrange
-        var optionsMonitor = Substitute.For<IOptionsMonitor<ActiveMqOptions>>();
-        var serviceProvider = Substitute.For<IServiceProvider>();
+        var optionsMonitor = IOptionsMonitor<ActiveMqOptions>.Mock();
+        var serviceProvider = IServiceProvider.Mock();
         var check = new ActiveMqHealthCheck(serviceProvider, optionsMonitor);
 
         // Act
@@ -33,8 +33,8 @@ public sealed class ActiveMqHealthCheckTests
     public async Task CheckHealthAsync_WhenCancellationTokenIsCancelled_ShouldReturnUnhealthy()
     {
         // Arrange
-        var optionsMonitor = Substitute.For<IOptionsMonitor<ActiveMqOptions>>();
-        var serviceProvider = Substitute.For<IServiceProvider>();
+        var optionsMonitor = IOptionsMonitor<ActiveMqOptions>.Mock();
+        var serviceProvider = IServiceProvider.Mock();
         var check = new ActiveMqHealthCheck(serviceProvider, optionsMonitor);
         var context = new HealthCheckContext
         {
@@ -57,8 +57,8 @@ public sealed class ActiveMqHealthCheckTests
     public async Task CheckHealthAsync_WhenOptionsAreNull_ShouldReturnUnhealthy()
     {
         // Arrange
-        var optionsMonitor = Substitute.For<IOptionsMonitor<ActiveMqOptions>>();
-        var serviceProvider = Substitute.For<IServiceProvider>();
+        var optionsMonitor = IOptionsMonitor<ActiveMqOptions>.Mock();
+        var serviceProvider = IServiceProvider.Mock();
         var check = new ActiveMqHealthCheck(serviceProvider, optionsMonitor);
         var context = new HealthCheckContext
         {

--- a/tests/NetEvolve.HealthChecks.Tests.Unit/Apache.Kafka/KafkaHealthCheckTests.cs
+++ b/tests/NetEvolve.HealthChecks.Tests.Unit/Apache.Kafka/KafkaHealthCheckTests.cs
@@ -7,7 +7,7 @@ using Microsoft.Extensions.Diagnostics.HealthChecks;
 using Microsoft.Extensions.Options;
 using NetEvolve.Extensions.TUnit;
 using NetEvolve.HealthChecks.Apache.Kafka;
-using NSubstitute;
+using TUnit.Mocks;
 
 [TestGroup($"{nameof(Apache)}.{nameof(Kafka)}")]
 public sealed class KafkaHealthCheckTests
@@ -18,8 +18,8 @@ public sealed class KafkaHealthCheckTests
     public async Task CheckHealthAsync_WhenContextNull_ThrowArgumentNullException()
     {
         // Arrange
-        var optionsMonitor = Substitute.For<IOptionsMonitor<KafkaOptions>>();
-        var serviceProvider = Substitute.For<IServiceProvider>();
+        var optionsMonitor = IOptionsMonitor<KafkaOptions>.Mock();
+        var serviceProvider = IServiceProvider.Mock();
         using var check = new KafkaHealthCheck(serviceProvider, optionsMonitor);
 
         // Act
@@ -33,8 +33,8 @@ public sealed class KafkaHealthCheckTests
     public async Task CheckHealthAsync_WhenCancellationTokenIsCancelled_ShouldReturnUnhealthy()
     {
         // Arrange
-        var optionsMonitor = Substitute.For<IOptionsMonitor<KafkaOptions>>();
-        var serviceProvider = Substitute.For<IServiceProvider>();
+        var optionsMonitor = IOptionsMonitor<KafkaOptions>.Mock();
+        var serviceProvider = IServiceProvider.Mock();
         using var check = new KafkaHealthCheck(serviceProvider, optionsMonitor);
         var context = new HealthCheckContext
         {
@@ -57,8 +57,8 @@ public sealed class KafkaHealthCheckTests
     public async Task CheckHealthAsync_WhenOptionsAreNull_ShouldReturnUnhealthy()
     {
         // Arrange
-        var optionsMonitor = Substitute.For<IOptionsMonitor<KafkaOptions>>();
-        var serviceProvider = Substitute.For<IServiceProvider>();
+        var optionsMonitor = IOptionsMonitor<KafkaOptions>.Mock();
+        var serviceProvider = IServiceProvider.Mock();
         using var check = new KafkaHealthCheck(serviceProvider, optionsMonitor);
         var context = new HealthCheckContext
         {

--- a/tests/NetEvolve.HealthChecks.Tests.Unit/Apache.RocketMQ/RocketMQHealthCheckTests.cs
+++ b/tests/NetEvolve.HealthChecks.Tests.Unit/Apache.RocketMQ/RocketMQHealthCheckTests.cs
@@ -7,7 +7,7 @@ using Microsoft.Extensions.Diagnostics.HealthChecks;
 using Microsoft.Extensions.Options;
 using NetEvolve.Extensions.TUnit;
 using NetEvolve.HealthChecks.Apache.RocketMQ;
-using NSubstitute;
+using TUnit.Mocks;
 
 [TestGroup($"{nameof(Apache)}.{nameof(RocketMQ)}")]
 public sealed class RocketMQHealthCheckTests
@@ -18,8 +18,8 @@ public sealed class RocketMQHealthCheckTests
     public async Task CheckHealthAsync_WhenContextNull_ThrowArgumentNullException()
     {
         // Arrange
-        var optionsMonitor = Substitute.For<IOptionsMonitor<RocketMQOptions>>();
-        var serviceProvider = Substitute.For<IServiceProvider>();
+        var optionsMonitor = IOptionsMonitor<RocketMQOptions>.Mock();
+        var serviceProvider = IServiceProvider.Mock();
         var check = new RocketMQHealthCheck(serviceProvider, optionsMonitor);
 
         // Act
@@ -33,8 +33,8 @@ public sealed class RocketMQHealthCheckTests
     public async Task CheckHealthAsync_WhenCancellationTokenIsCancelled_ShouldReturnUnhealthy()
     {
         // Arrange
-        var optionsMonitor = Substitute.For<IOptionsMonitor<RocketMQOptions>>();
-        var serviceProvider = Substitute.For<IServiceProvider>();
+        var optionsMonitor = IOptionsMonitor<RocketMQOptions>.Mock();
+        var serviceProvider = IServiceProvider.Mock();
         var check = new RocketMQHealthCheck(serviceProvider, optionsMonitor);
         var context = new HealthCheckContext
         {
@@ -57,8 +57,8 @@ public sealed class RocketMQHealthCheckTests
     public async Task CheckHealthAsync_WhenOptionsAreNull_ShouldReturnUnhealthy()
     {
         // Arrange
-        var optionsMonitor = Substitute.For<IOptionsMonitor<RocketMQOptions>>();
-        var serviceProvider = Substitute.For<IServiceProvider>();
+        var optionsMonitor = IOptionsMonitor<RocketMQOptions>.Mock();
+        var serviceProvider = IServiceProvider.Mock();
         var check = new RocketMQHealthCheck(serviceProvider, optionsMonitor);
         var context = new HealthCheckContext
         {

--- a/tests/NetEvolve.HealthChecks.Tests.Unit/Apache.Solr/SolrHealthCheckTests.cs
+++ b/tests/NetEvolve.HealthChecks.Tests.Unit/Apache.Solr/SolrHealthCheckTests.cs
@@ -7,7 +7,7 @@ using Microsoft.Extensions.Diagnostics.HealthChecks;
 using Microsoft.Extensions.Options;
 using NetEvolve.Extensions.TUnit;
 using NetEvolve.HealthChecks.Apache.Solr;
-using NSubstitute;
+using TUnit.Mocks;
 
 [TestGroup($"{nameof(Apache)}.{nameof(Solr)}")]
 public sealed class SolrHealthCheckTests
@@ -18,8 +18,8 @@ public sealed class SolrHealthCheckTests
     public async Task CheckHealthAsync_WhenContextNull_ThrowArgumentNullException()
     {
         // Arrange
-        var optionsMonitor = Substitute.For<IOptionsMonitor<SolrOptions>>();
-        var serviceProvider = Substitute.For<IServiceProvider>();
+        var optionsMonitor = IOptionsMonitor<SolrOptions>.Mock();
+        var serviceProvider = IServiceProvider.Mock();
         var check = new SolrHealthCheck(serviceProvider, optionsMonitor);
 
         // Act
@@ -33,8 +33,8 @@ public sealed class SolrHealthCheckTests
     public async Task CheckHealthAsync_WhenCancellationTokenIsCancelled_ShouldReturnUnhealthy()
     {
         // Arrange
-        var optionsMonitor = Substitute.For<IOptionsMonitor<SolrOptions>>();
-        var serviceProvider = Substitute.For<IServiceProvider>();
+        var optionsMonitor = IOptionsMonitor<SolrOptions>.Mock();
+        var serviceProvider = IServiceProvider.Mock();
         var check = new SolrHealthCheck(serviceProvider, optionsMonitor);
         var context = new HealthCheckContext
         {
@@ -57,8 +57,8 @@ public sealed class SolrHealthCheckTests
     public async Task CheckHealthAsync_WhenOptionsAreNull_ShouldReturnUnhealthy()
     {
         // Arrange
-        var optionsMonitor = Substitute.For<IOptionsMonitor<SolrOptions>>();
-        var serviceProvider = Substitute.For<IServiceProvider>();
+        var optionsMonitor = IOptionsMonitor<SolrOptions>.Mock();
+        var serviceProvider = IServiceProvider.Mock();
         var check = new SolrHealthCheck(serviceProvider, optionsMonitor);
         var context = new HealthCheckContext
         {

--- a/tests/NetEvolve.HealthChecks.Tests.Unit/ArangoDb/ArangoDbHealthCheckTests.cs
+++ b/tests/NetEvolve.HealthChecks.Tests.Unit/ArangoDb/ArangoDbHealthCheckTests.cs
@@ -10,7 +10,7 @@ using Microsoft.Extensions.Diagnostics.HealthChecks;
 using Microsoft.Extensions.Options;
 using NetEvolve.Extensions.TUnit;
 using NetEvolve.HealthChecks.ArangoDb;
-using NSubstitute;
+using TUnit.Mocks;
 
 [TestGroup(nameof(ArangoDb))]
 public sealed class ArangoDbHealthCheckTests
@@ -21,8 +21,8 @@ public sealed class ArangoDbHealthCheckTests
     public async Task CheckHealthAsync_WhenContextNull_ThrowArgumentNullException()
     {
         // Arrange
-        var serviceProvider = Substitute.For<IServiceProvider>();
-        var optionsMonitor = Substitute.For<IOptionsMonitor<ArangoDbOptions>>();
+        var serviceProvider = IServiceProvider.Mock();
+        var optionsMonitor = IOptionsMonitor<ArangoDbOptions>.Mock();
         var check = new ArangoDbHealthCheck(serviceProvider, optionsMonitor);
 
         // Act
@@ -36,8 +36,8 @@ public sealed class ArangoDbHealthCheckTests
     public async Task CheckHealthAsync_WhenCancellationTokenIsCancelled_ShouldReturnUnhealthy()
     {
         // Arrange
-        var serviceProvider = Substitute.For<IServiceProvider>();
-        var optionsMonitor = Substitute.For<IOptionsMonitor<ArangoDbOptions>>();
+        var serviceProvider = IServiceProvider.Mock();
+        var optionsMonitor = IOptionsMonitor<ArangoDbOptions>.Mock();
 
         var check = new ArangoDbHealthCheck(serviceProvider, optionsMonitor);
         var context = new HealthCheckContext
@@ -61,8 +61,8 @@ public sealed class ArangoDbHealthCheckTests
     public async Task CheckHealthAsync_WhenOptionsAreNull_ShouldReturnUnhealthy()
     {
         // Arrange
-        var serviceProvider = Substitute.For<IServiceProvider>();
-        var optionsMonitor = Substitute.For<IOptionsMonitor<ArangoDbOptions>>();
+        var serviceProvider = IServiceProvider.Mock();
+        var optionsMonitor = IOptionsMonitor<ArangoDbOptions>.Mock();
 
         var check = new ArangoDbHealthCheck(serviceProvider, optionsMonitor);
         var context = new HealthCheckContext
@@ -98,11 +98,11 @@ public sealed class ArangoDbHealthCheckTests
             },
         };
 
-        var optionsMonitor = Substitute.For<IOptionsMonitor<ArangoDbOptions>>();
+        var optionsMonitor = IOptionsMonitor<ArangoDbOptions>.Mock();
         _ = optionsMonitor.Get(TestName).Returns(options);
 
         // Setup client mock that returns success
-        var transport = Substitute.For<HttpClient>();
+        var transport = HttpClient.Mock();
         using var client = new ArangoDBClient(transport);
 
         var serviceProvider = new ServiceCollection().AddKeyedSingleton(serviceKey, client).BuildServiceProvider();
@@ -140,7 +140,7 @@ public sealed class ArangoDbHealthCheckTests
             },
         };
 
-        var optionsMonitor = Substitute.For<IOptionsMonitor<ArangoDbOptions>>();
+        var optionsMonitor = IOptionsMonitor<ArangoDbOptions>.Mock();
         _ = optionsMonitor.Get(TestName).Returns(options);
 
         // Setup connection mock that returns success
@@ -182,7 +182,7 @@ public sealed class ArangoDbHealthCheckTests
             },
         };
 
-        var optionsMonitor = Substitute.For<IOptionsMonitor<ArangoDbOptions>>();
+        var optionsMonitor = IOptionsMonitor<ArangoDbOptions>.Mock();
         _ = optionsMonitor.Get(TestName).Returns(options);
 
         // Setup connection mock that throws an exception

--- a/tests/NetEvolve.HealthChecks.Tests.Unit/Azure.EventHubs/EventHubsClientFactoryTests.cs
+++ b/tests/NetEvolve.HealthChecks.Tests.Unit/Azure.EventHubs/EventHubsClientFactoryTests.cs
@@ -6,7 +6,7 @@ using global::Azure.Messaging.EventHubs.Producer;
 using Microsoft.Extensions.DependencyInjection;
 using NetEvolve.Extensions.TUnit;
 using NetEvolve.HealthChecks.Azure.EventHubs;
-using NSubstitute;
+using TUnit.Mocks;
 
 [TestGroup($"{nameof(Azure)}.{nameof(EventHubs)}")]
 public sealed class EventHubsClientFactoryTests
@@ -23,7 +23,7 @@ public sealed class EventHubsClientFactoryTests
             ConnectionString = connectionString,
             EventHubName = "eventhub1",
         };
-        var serviceProvider = Substitute.For<IServiceProvider>();
+        var serviceProvider = IServiceProvider.Mock();
         using var clientFactory = new EventHubsClientFactory();
 
         // Act
@@ -48,7 +48,7 @@ public sealed class EventHubsClientFactoryTests
             FullyQualifiedNamespace = fullyQualifiedNamespace,
             EventHubName = "eventhub1",
         };
-        var serviceProvider = Substitute.For<IServiceProvider>();
+        var serviceProvider = IServiceProvider.Mock();
         using var clientFactory = new EventHubsClientFactory();
 
         // Act
@@ -66,8 +66,12 @@ public sealed class EventHubsClientFactoryTests
     public async Task GetClient_WhenModeIsServiceProvider_ShouldReturnRegisteredClient()
     {
         // Arrange
-        var mockClient = Substitute.For<EventHubProducerClient>();
-        var services = new ServiceCollection().AddSingleton(mockClient);
+        var mockClient = EventHubProducerClient.Mock();
+        // Convert once to the real type and reuse that instance everywhere below - each implicit
+        // conversion from the mock wrapper to the real type can mint a distinct proxy instance, so
+        // converting again later (e.g. at the assertion) would compare against a different object.
+        EventHubProducerClient registeredClient = mockClient;
+        var services = new ServiceCollection().AddSingleton(registeredClient);
         await using var serviceProvider = services.BuildServiceProvider();
 
         var options = new EventHubsOptions { Mode = ClientCreationMode.ServiceProvider, EventHubName = "eventhub1" };
@@ -81,7 +85,7 @@ public sealed class EventHubsClientFactoryTests
         );
 
         // Assert
-        _ = await Assert.That(client).IsSameReferenceAs(mockClient);
+        _ = await Assert.That(client).IsSameReferenceAs(registeredClient);
     }
 
     [Test]
@@ -96,7 +100,7 @@ public sealed class EventHubsClientFactoryTests
             ConnectionString = connectionString,
             EventHubName = "eventhub1",
         };
-        var serviceProvider = Substitute.For<IServiceProvider>();
+        var serviceProvider = IServiceProvider.Mock();
         using var clientFactory = new EventHubsClientFactory();
 
         // Act
@@ -127,7 +131,7 @@ public sealed class EventHubsClientFactoryTests
             ConnectionString = connectionString,
             EventHubName = "eventhub1",
         };
-        var serviceProvider = Substitute.For<IServiceProvider>();
+        var serviceProvider = IServiceProvider.Mock();
         using var clientFactory = new EventHubsClientFactory();
 
         // Act
@@ -150,7 +154,7 @@ public sealed class EventHubsClientFactoryTests
             ConnectionString = connectionString,
             EventHubName = "eventhub1",
         };
-        var serviceProvider = Substitute.For<IServiceProvider>();
+        var serviceProvider = IServiceProvider.Mock();
         using var clientFactory = new EventHubsClientFactory();
 
         // Act
@@ -166,7 +170,7 @@ public sealed class EventHubsClientFactoryTests
     {
         // Arrange
         var options = new EventHubsOptions { Mode = (ClientCreationMode)int.MaxValue, EventHubName = "eventhub1" };
-        var serviceProvider = Substitute.For<IServiceProvider>();
+        var serviceProvider = IServiceProvider.Mock();
         using var clientFactory = new EventHubsClientFactory();
 
         // Act

--- a/tests/NetEvolve.HealthChecks.Tests.Unit/Azure.EventHubs/EventHubsHealthCheckTests.cs
+++ b/tests/NetEvolve.HealthChecks.Tests.Unit/Azure.EventHubs/EventHubsHealthCheckTests.cs
@@ -7,7 +7,7 @@ using Microsoft.Extensions.Diagnostics.HealthChecks;
 using Microsoft.Extensions.Options;
 using NetEvolve.Extensions.TUnit;
 using NetEvolve.HealthChecks.Azure.EventHubs;
-using NSubstitute;
+using TUnit.Mocks;
 
 [TestGroup($"{nameof(Azure)}.{nameof(EventHubs)}")]
 public sealed class EventHubsHealthCheckTests
@@ -18,8 +18,8 @@ public sealed class EventHubsHealthCheckTests
     public async Task CheckHealthAsync_WhenContextNull_ThrowArgumentNullException()
     {
         // Arrange
-        var optionsMonitor = Substitute.For<IOptionsMonitor<EventHubsOptions>>();
-        var serviceProvider = Substitute.For<IServiceProvider>();
+        var optionsMonitor = IOptionsMonitor<EventHubsOptions>.Mock();
+        var serviceProvider = IServiceProvider.Mock();
         var check = new EventHubsHealthCheck(serviceProvider, optionsMonitor);
 
         // Act
@@ -33,8 +33,8 @@ public sealed class EventHubsHealthCheckTests
     public async Task CheckHealthAsync_WhenCancellationTokenIsCancelled_ShouldReturnUnhealthy()
     {
         // Arrange
-        var optionsMonitor = Substitute.For<IOptionsMonitor<EventHubsOptions>>();
-        var serviceProvider = Substitute.For<IServiceProvider>();
+        var optionsMonitor = IOptionsMonitor<EventHubsOptions>.Mock();
+        var serviceProvider = IServiceProvider.Mock();
         var check = new EventHubsHealthCheck(serviceProvider, optionsMonitor);
         var context = new HealthCheckContext
         {
@@ -57,9 +57,9 @@ public sealed class EventHubsHealthCheckTests
     public async Task CheckHealthAsync_WhenOptionsAreNull_ShouldReturnUnhealthy()
     {
         // Arrange
-        var optionsMonitor = Substitute.For<IOptionsMonitor<EventHubsOptions>>();
+        var optionsMonitor = IOptionsMonitor<EventHubsOptions>.Mock();
         _ = optionsMonitor.Get(TestName).Returns((EventHubsOptions)null!);
-        var serviceProvider = Substitute.For<IServiceProvider>();
+        var serviceProvider = IServiceProvider.Mock();
         var check = new EventHubsHealthCheck(serviceProvider, optionsMonitor);
         var context = new HealthCheckContext
         {

--- a/tests/NetEvolve.HealthChecks.Tests.Unit/Azure.ServiceBus/ServiceBusClientFactoryTests.cs
+++ b/tests/NetEvolve.HealthChecks.Tests.Unit/Azure.ServiceBus/ServiceBusClientFactoryTests.cs
@@ -5,7 +5,7 @@ using System.Diagnostics;
 using Microsoft.Extensions.DependencyInjection;
 using NetEvolve.Extensions.TUnit;
 using NetEvolve.HealthChecks.Azure.ServiceBus;
-using NSubstitute;
+using TUnit.Mocks;
 
 [TestGroup($"{nameof(Azure)}.{nameof(ServiceBus)}")]
 public sealed class ServiceBusClientFactoryTests
@@ -21,7 +21,7 @@ public sealed class ServiceBusClientFactoryTests
             Mode = ClientCreationMode.ConnectionString,
             ConnectionString = connectionString,
         };
-        var serviceProvider = Substitute.For<IServiceProvider>();
+        var serviceProvider = IServiceProvider.Mock();
         var clientFactory = new ServiceBusClientFactory();
 
         // Act
@@ -45,7 +45,7 @@ public sealed class ServiceBusClientFactoryTests
             Mode = ClientCreationMode.DefaultAzureCredentials,
             FullyQualifiedNamespace = fullyQualifiedNamespace,
         };
-        var serviceProvider = Substitute.For<IServiceProvider>();
+        var serviceProvider = IServiceProvider.Mock();
         var clientFactory = new ServiceBusClientFactory();
 
         // Act
@@ -70,7 +70,7 @@ public sealed class ServiceBusClientFactoryTests
             Mode = ClientCreationMode.ConnectionString,
             ConnectionString = connectionString,
         };
-        var serviceProvider = Substitute.For<IServiceProvider>();
+        var serviceProvider = IServiceProvider.Mock();
         var clientFactory = new ServiceBusClientFactory();
 
         // Act
@@ -100,7 +100,7 @@ public sealed class ServiceBusClientFactoryTests
             Mode = ClientCreationMode.ConnectionString,
             ConnectionString = connectionString,
         };
-        var serviceProvider = Substitute.For<IServiceProvider>();
+        var serviceProvider = IServiceProvider.Mock();
         var clientFactory = new ServiceBusClientFactory();
 
         // Act
@@ -124,7 +124,7 @@ public sealed class ServiceBusClientFactoryTests
             Mode = ClientCreationMode.DefaultAzureCredentials,
             FullyQualifiedNamespace = fullyQualifiedNamespace,
         };
-        var serviceProvider = Substitute.For<IServiceProvider>();
+        var serviceProvider = IServiceProvider.Mock();
         var clientFactory = new ServiceBusClientFactory();
 
         // Act
@@ -149,7 +149,7 @@ public sealed class ServiceBusClientFactoryTests
             Mode = ClientCreationMode.ConnectionString,
             ConnectionString = connectionString,
         };
-        var serviceProvider = Substitute.For<IServiceProvider>();
+        var serviceProvider = IServiceProvider.Mock();
         var clientFactory = new ServiceBusClientFactory();
 
         // Act
@@ -173,7 +173,7 @@ public sealed class ServiceBusClientFactoryTests
     {
         // Arrange
         var options = new ServiceBusQueueOptions { Mode = (ClientCreationMode)int.MaxValue };
-        var serviceProvider = Substitute.For<IServiceProvider>();
+        var serviceProvider = IServiceProvider.Mock();
         var clientFactory = new ServiceBusClientFactory();
 
         // Act
@@ -193,7 +193,7 @@ public sealed class ServiceBusClientFactoryTests
     {
         // Arrange
         var options = new ServiceBusQueueOptions { Mode = (ClientCreationMode)int.MaxValue };
-        var serviceProvider = Substitute.For<IServiceProvider>();
+        var serviceProvider = IServiceProvider.Mock();
         var clientFactory = new ServiceBusClientFactory();
 
         // Act

--- a/tests/NetEvolve.HealthChecks.Tests.Unit/Azure.ServiceBus/ServiceBusQueueHealthCheckTests.cs
+++ b/tests/NetEvolve.HealthChecks.Tests.Unit/Azure.ServiceBus/ServiceBusQueueHealthCheckTests.cs
@@ -1,4 +1,4 @@
-﻿namespace NetEvolve.HealthChecks.Tests.Unit.Azure.ServiceBus;
+namespace NetEvolve.HealthChecks.Tests.Unit.Azure.ServiceBus;
 
 using System;
 using System.Threading;
@@ -7,7 +7,7 @@ using Microsoft.Extensions.Diagnostics.HealthChecks;
 using Microsoft.Extensions.Options;
 using NetEvolve.Extensions.TUnit;
 using NetEvolve.HealthChecks.Azure.ServiceBus;
-using NSubstitute;
+using TUnit.Mocks;
 
 [TestGroup($"{nameof(Azure)}.{nameof(ServiceBus)}")]
 [TestGroup($"{nameof(Azure)}.{nameof(ServiceBus)}.Queue")]
@@ -19,8 +19,8 @@ public sealed class ServiceBusQueueHealthCheckTests
     public async Task CheckHealthAsync_WhenContextNull_ThrowArgumentNullException()
     {
         // Arrange
-        var optionsMonitor = Substitute.For<IOptionsMonitor<ServiceBusQueueOptions>>();
-        var serviceProvider = Substitute.For<IServiceProvider>();
+        var optionsMonitor = IOptionsMonitor<ServiceBusQueueOptions>.Mock();
+        var serviceProvider = IServiceProvider.Mock();
         var check = new ServiceBusQueueHealthCheck(serviceProvider, optionsMonitor);
 
         // Act
@@ -34,8 +34,8 @@ public sealed class ServiceBusQueueHealthCheckTests
     public async Task CheckHealthAsync_WhenCancellationTokenIsCancelled_ShouldReturnUnhealthy()
     {
         // Arrange
-        var optionsMonitor = Substitute.For<IOptionsMonitor<ServiceBusQueueOptions>>();
-        var serviceProvider = Substitute.For<IServiceProvider>();
+        var optionsMonitor = IOptionsMonitor<ServiceBusQueueOptions>.Mock();
+        var serviceProvider = IServiceProvider.Mock();
         var check = new ServiceBusQueueHealthCheck(serviceProvider, optionsMonitor);
         var context = new HealthCheckContext
         {
@@ -58,9 +58,9 @@ public sealed class ServiceBusQueueHealthCheckTests
     public async Task CheckHealthAsync_WhenOptionsAreNull_ShouldReturnUnhealthy()
     {
         // Arrange
-        var optionsMonitor = Substitute.For<IOptionsMonitor<ServiceBusQueueOptions>>();
+        var optionsMonitor = IOptionsMonitor<ServiceBusQueueOptions>.Mock();
         _ = optionsMonitor.Get(TestName).Returns((ServiceBusQueueOptions)null!);
-        var serviceProvider = Substitute.For<IServiceProvider>();
+        var serviceProvider = IServiceProvider.Mock();
         var check = new ServiceBusQueueHealthCheck(serviceProvider, optionsMonitor);
         var context = new HealthCheckContext
         {

--- a/tests/NetEvolve.HealthChecks.Tests.Unit/Azure.ServiceBus/ServiceBusSubscriptionHealthCheckTests.cs
+++ b/tests/NetEvolve.HealthChecks.Tests.Unit/Azure.ServiceBus/ServiceBusSubscriptionHealthCheckTests.cs
@@ -7,7 +7,7 @@ using Microsoft.Extensions.Diagnostics.HealthChecks;
 using Microsoft.Extensions.Options;
 using NetEvolve.Extensions.TUnit;
 using NetEvolve.HealthChecks.Azure.ServiceBus;
-using NSubstitute;
+using TUnit.Mocks;
 
 [TestGroup($"{nameof(Azure)}.{nameof(ServiceBus)}")]
 [TestGroup($"{nameof(Azure)}.{nameof(ServiceBus)}.Subscription")]
@@ -19,8 +19,8 @@ public sealed class ServiceBusSubscriptionHealthCheckTests
     public async Task CheckHealthAsync_WhenContextNull_ThrowArgumentNullException()
     {
         // Arrange
-        var optionsMonitor = Substitute.For<IOptionsMonitor<ServiceBusSubscriptionOptions>>();
-        var serviceProvider = Substitute.For<IServiceProvider>();
+        var optionsMonitor = IOptionsMonitor<ServiceBusSubscriptionOptions>.Mock();
+        var serviceProvider = IServiceProvider.Mock();
         var check = new ServiceBusSubscriptionHealthCheck(serviceProvider, optionsMonitor);
 
         // Act
@@ -34,8 +34,8 @@ public sealed class ServiceBusSubscriptionHealthCheckTests
     public async Task CheckHealthAsync_WhenCancellationTokenIsCancelled_ShouldReturnUnhealthy()
     {
         // Arrange
-        var optionsMonitor = Substitute.For<IOptionsMonitor<ServiceBusSubscriptionOptions>>();
-        var serviceProvider = Substitute.For<IServiceProvider>();
+        var optionsMonitor = IOptionsMonitor<ServiceBusSubscriptionOptions>.Mock();
+        var serviceProvider = IServiceProvider.Mock();
         var check = new ServiceBusSubscriptionHealthCheck(serviceProvider, optionsMonitor);
         var context = new HealthCheckContext
         {
@@ -58,9 +58,9 @@ public sealed class ServiceBusSubscriptionHealthCheckTests
     public async Task CheckHealthAsync_WhenOptionsAreNull_ShouldReturnUnhealthy()
     {
         // Arrange
-        var optionsMonitor = Substitute.For<IOptionsMonitor<ServiceBusSubscriptionOptions>>();
+        var optionsMonitor = IOptionsMonitor<ServiceBusSubscriptionOptions>.Mock();
         _ = optionsMonitor.Get(TestName).Returns((ServiceBusSubscriptionOptions)null!);
-        var serviceProvider = Substitute.For<IServiceProvider>();
+        var serviceProvider = IServiceProvider.Mock();
         var check = new ServiceBusSubscriptionHealthCheck(serviceProvider, optionsMonitor);
         var context = new HealthCheckContext
         {

--- a/tests/NetEvolve.HealthChecks.Tests.Unit/Azure.ServiceBus/ServiceBusTopicHealthCheckTests.cs
+++ b/tests/NetEvolve.HealthChecks.Tests.Unit/Azure.ServiceBus/ServiceBusTopicHealthCheckTests.cs
@@ -7,7 +7,7 @@ using Microsoft.Extensions.Diagnostics.HealthChecks;
 using Microsoft.Extensions.Options;
 using NetEvolve.Extensions.TUnit;
 using NetEvolve.HealthChecks.Azure.ServiceBus;
-using NSubstitute;
+using TUnit.Mocks;
 
 [TestGroup($"{nameof(Azure)}.{nameof(ServiceBus)}")]
 [TestGroup($"{nameof(Azure)}.{nameof(ServiceBus)}.Topic")]
@@ -19,8 +19,8 @@ public sealed class ServiceBusTopicHealthCheckTests
     public async Task CheckHealthAsync_WhenContextNull_ThrowArgumentNullException()
     {
         // Arrange
-        var optionsMonitor = Substitute.For<IOptionsMonitor<ServiceBusTopicOptions>>();
-        var serviceProvider = Substitute.For<IServiceProvider>();
+        var optionsMonitor = IOptionsMonitor<ServiceBusTopicOptions>.Mock();
+        var serviceProvider = IServiceProvider.Mock();
         var check = new ServiceBusTopicHealthCheck(serviceProvider, optionsMonitor);
 
         // Act
@@ -34,8 +34,8 @@ public sealed class ServiceBusTopicHealthCheckTests
     public async Task CheckHealthAsync_WhenCancellationTokenIsCancelled_ShouldReturnUnhealthy()
     {
         // Arrange
-        var optionsMonitor = Substitute.For<IOptionsMonitor<ServiceBusTopicOptions>>();
-        var serviceProvider = Substitute.For<IServiceProvider>();
+        var optionsMonitor = IOptionsMonitor<ServiceBusTopicOptions>.Mock();
+        var serviceProvider = IServiceProvider.Mock();
         var check = new ServiceBusTopicHealthCheck(serviceProvider, optionsMonitor);
         var context = new HealthCheckContext
         {
@@ -58,9 +58,9 @@ public sealed class ServiceBusTopicHealthCheckTests
     public async Task CheckHealthAsync_WhenOptionsAreNull_ShouldReturnUnhealthy()
     {
         // Arrange
-        var optionsMonitor = Substitute.For<IOptionsMonitor<ServiceBusTopicOptions>>();
+        var optionsMonitor = IOptionsMonitor<ServiceBusTopicOptions>.Mock();
         _ = optionsMonitor.Get(TestName).Returns((ServiceBusTopicOptions)null!);
-        var serviceProvider = Substitute.For<IServiceProvider>();
+        var serviceProvider = IServiceProvider.Mock();
         var check = new ServiceBusTopicHealthCheck(serviceProvider, optionsMonitor);
         var context = new HealthCheckContext
         {

--- a/tests/NetEvolve.HealthChecks.Tests.Unit/ClickHouse/ClickHouseHealthCheckTests.cs
+++ b/tests/NetEvolve.HealthChecks.Tests.Unit/ClickHouse/ClickHouseHealthCheckTests.cs
@@ -7,7 +7,7 @@ using Microsoft.Extensions.Diagnostics.HealthChecks;
 using Microsoft.Extensions.Options;
 using NetEvolve.Extensions.TUnit;
 using NetEvolve.HealthChecks.ClickHouse;
-using NSubstitute;
+using TUnit.Mocks;
 
 [TestGroup(nameof(ClickHouse))]
 public sealed class ClickHouseHealthCheckTests
@@ -18,7 +18,7 @@ public sealed class ClickHouseHealthCheckTests
     public async Task CheckHealthAsync_WhenContextNull_ThrowArgumentNullException()
     {
         // Arrange
-        var optionsMonitor = Substitute.For<IOptionsMonitor<ClickHouseOptions>>();
+        var optionsMonitor = IOptionsMonitor<ClickHouseOptions>.Mock();
         var check = new ClickHouseHealthCheck(optionsMonitor);
 
         // Act
@@ -32,7 +32,7 @@ public sealed class ClickHouseHealthCheckTests
     public async Task CheckHealthAsync_WhenCancellationTokenIsCancelled_ShouldReturnUnhealthy()
     {
         // Arrange
-        var optionsMonitor = Substitute.For<IOptionsMonitor<ClickHouseOptions>>();
+        var optionsMonitor = IOptionsMonitor<ClickHouseOptions>.Mock();
         var check = new ClickHouseHealthCheck(optionsMonitor);
         var context = new HealthCheckContext
         {
@@ -55,7 +55,7 @@ public sealed class ClickHouseHealthCheckTests
     public async Task CheckHealthAsync_WhenOptionsAreNull_ShouldReturnUnhealthy()
     {
         // Arrange
-        var optionsMonitor = Substitute.For<IOptionsMonitor<ClickHouseOptions>>();
+        var optionsMonitor = IOptionsMonitor<ClickHouseOptions>.Mock();
         var check = new ClickHouseHealthCheck(optionsMonitor);
         var context = new HealthCheckContext
         {

--- a/tests/NetEvolve.HealthChecks.Tests.Unit/CockroachDb/CockroachDbHealthCheckTests.cs
+++ b/tests/NetEvolve.HealthChecks.Tests.Unit/CockroachDb/CockroachDbHealthCheckTests.cs
@@ -7,7 +7,7 @@ using Microsoft.Extensions.Diagnostics.HealthChecks;
 using Microsoft.Extensions.Options;
 using NetEvolve.Extensions.TUnit;
 using NetEvolve.HealthChecks.CockroachDb;
-using NSubstitute;
+using TUnit.Mocks;
 
 [TestGroup(nameof(CockroachDb))]
 public sealed class CockroachDbHealthCheckTests
@@ -18,7 +18,7 @@ public sealed class CockroachDbHealthCheckTests
     public async Task CheckHealthAsync_WhenContextNull_ThrowArgumentNullException()
     {
         // Arrange
-        var optionsMonitor = Substitute.For<IOptionsMonitor<CockroachDbOptions>>();
+        var optionsMonitor = IOptionsMonitor<CockroachDbOptions>.Mock();
         var check = new CockroachDbHealthCheck(optionsMonitor);
 
         // Act
@@ -32,7 +32,7 @@ public sealed class CockroachDbHealthCheckTests
     public async Task CheckHealthAsync_WhenCancellationTokenIsCancelled_ShouldReturnUnhealthy()
     {
         // Arrange
-        var optionsMonitor = Substitute.For<IOptionsMonitor<CockroachDbOptions>>();
+        var optionsMonitor = IOptionsMonitor<CockroachDbOptions>.Mock();
         var check = new CockroachDbHealthCheck(optionsMonitor);
         var context = new HealthCheckContext
         {
@@ -55,7 +55,7 @@ public sealed class CockroachDbHealthCheckTests
     public async Task CheckHealthAsync_WhenOptionsAreNull_ShouldReturnUnhealthy()
     {
         // Arrange
-        var optionsMonitor = Substitute.For<IOptionsMonitor<CockroachDbOptions>>();
+        var optionsMonitor = IOptionsMonitor<CockroachDbOptions>.Mock();
         var check = new CockroachDbHealthCheck(optionsMonitor);
         var context = new HealthCheckContext
         {

--- a/tests/NetEvolve.HealthChecks.Tests.Unit/Consul/ConsulHealthCheckTests.cs
+++ b/tests/NetEvolve.HealthChecks.Tests.Unit/Consul/ConsulHealthCheckTests.cs
@@ -1,4 +1,4 @@
-﻿namespace NetEvolve.HealthChecks.Tests.Unit.Consul;
+namespace NetEvolve.HealthChecks.Tests.Unit.Consul;
 
 using System;
 using System.Threading;
@@ -7,7 +7,7 @@ using Microsoft.Extensions.Diagnostics.HealthChecks;
 using Microsoft.Extensions.Options;
 using NetEvolve.Extensions.TUnit;
 using NetEvolve.HealthChecks.Consul;
-using NSubstitute;
+using TUnit.Mocks;
 
 [TestGroup(nameof(Consul))]
 public sealed class ConsulHealthCheckTests
@@ -18,8 +18,8 @@ public sealed class ConsulHealthCheckTests
     public async Task CheckHealthAsync_WhenContextNull_ThrowArgumentNullException()
     {
         // Arrange
-        var optionsMonitor = Substitute.For<IOptionsMonitor<ConsulOptions>>();
-        var serviceProvider = Substitute.For<IServiceProvider>();
+        var optionsMonitor = IOptionsMonitor<ConsulOptions>.Mock();
+        var serviceProvider = IServiceProvider.Mock();
         var check = new ConsulHealthCheck(serviceProvider, optionsMonitor);
 
         // Act
@@ -33,8 +33,8 @@ public sealed class ConsulHealthCheckTests
     public async Task CheckHealthAsync_WhenCancellationTokenIsCancelled_ShouldReturnUnhealthy()
     {
         // Arrange
-        var optionsMonitor = Substitute.For<IOptionsMonitor<ConsulOptions>>();
-        var serviceProvider = Substitute.For<IServiceProvider>();
+        var optionsMonitor = IOptionsMonitor<ConsulOptions>.Mock();
+        var serviceProvider = IServiceProvider.Mock();
         var check = new ConsulHealthCheck(serviceProvider, optionsMonitor);
         var context = new HealthCheckContext
         {
@@ -57,8 +57,8 @@ public sealed class ConsulHealthCheckTests
     public async Task CheckHealthAsync_WhenOptionsAreNull_ShouldReturnUnhealthy()
     {
         // Arrange
-        var optionsMonitor = Substitute.For<IOptionsMonitor<ConsulOptions>>();
-        var serviceProvider = Substitute.For<IServiceProvider>();
+        var optionsMonitor = IOptionsMonitor<ConsulOptions>.Mock();
+        var serviceProvider = IServiceProvider.Mock();
         var check = new ConsulHealthCheck(serviceProvider, optionsMonitor);
         var context = new HealthCheckContext
         {

--- a/tests/NetEvolve.HealthChecks.Tests.Unit/CouchDb/CouchDbHealthCheckTests.cs
+++ b/tests/NetEvolve.HealthChecks.Tests.Unit/CouchDb/CouchDbHealthCheckTests.cs
@@ -7,7 +7,7 @@ using Microsoft.Extensions.Diagnostics.HealthChecks;
 using Microsoft.Extensions.Options;
 using NetEvolve.Extensions.TUnit;
 using NetEvolve.HealthChecks.CouchDb;
-using NSubstitute;
+using TUnit.Mocks;
 
 [TestGroup(nameof(CouchDb))]
 public sealed class CouchDbHealthCheckTests
@@ -18,8 +18,8 @@ public sealed class CouchDbHealthCheckTests
     public async Task CheckHealthAsync_WhenContextNull_ThrowArgumentNullException()
     {
         // Arrange
-        var serviceProvider = Substitute.For<IServiceProvider>();
-        var optionsMonitor = Substitute.For<IOptionsMonitor<CouchDbOptions>>();
+        var serviceProvider = IServiceProvider.Mock();
+        var optionsMonitor = IOptionsMonitor<CouchDbOptions>.Mock();
         var check = new CouchDbHealthCheck(serviceProvider, optionsMonitor);
 
         // Act
@@ -33,8 +33,8 @@ public sealed class CouchDbHealthCheckTests
     public async Task CheckHealthAsync_WhenCancellationTokenIsCancelled_ShouldReturnUnhealthy()
     {
         // Arrange
-        var serviceProvider = Substitute.For<IServiceProvider>();
-        var optionsMonitor = Substitute.For<IOptionsMonitor<CouchDbOptions>>();
+        var serviceProvider = IServiceProvider.Mock();
+        var optionsMonitor = IOptionsMonitor<CouchDbOptions>.Mock();
 
         var check = new CouchDbHealthCheck(serviceProvider, optionsMonitor);
         var context = new HealthCheckContext
@@ -58,8 +58,8 @@ public sealed class CouchDbHealthCheckTests
     public async Task CheckHealthAsync_WhenOptionsAreNull_ShouldReturnUnhealthy()
     {
         // Arrange
-        var serviceProvider = Substitute.For<IServiceProvider>();
-        var optionsMonitor = Substitute.For<IOptionsMonitor<CouchDbOptions>>();
+        var serviceProvider = IServiceProvider.Mock();
+        var optionsMonitor = IOptionsMonitor<CouchDbOptions>.Mock();
 
         var check = new CouchDbHealthCheck(serviceProvider, optionsMonitor);
         var context = new HealthCheckContext

--- a/tests/NetEvolve.HealthChecks.Tests.Unit/Couchbase/CouchbaseHealthCheckTests.cs
+++ b/tests/NetEvolve.HealthChecks.Tests.Unit/Couchbase/CouchbaseHealthCheckTests.cs
@@ -9,7 +9,7 @@ using Microsoft.Extensions.Diagnostics.HealthChecks;
 using Microsoft.Extensions.Options;
 using NetEvolve.Extensions.TUnit;
 using NetEvolve.HealthChecks.Couchbase;
-using NSubstitute;
+using TUnit.Mocks;
 
 [TestGroup(nameof(Couchbase))]
 public sealed class CouchbaseHealthCheckTests
@@ -20,8 +20,8 @@ public sealed class CouchbaseHealthCheckTests
     public async Task CheckHealthAsync_WhenContextNull_ThrowArgumentNullException()
     {
         // Arrange
-        var serviceProvider = Substitute.For<IServiceProvider>();
-        var optionsMonitor = Substitute.For<IOptionsMonitor<CouchbaseOptions>>();
+        var serviceProvider = IServiceProvider.Mock();
+        var optionsMonitor = IOptionsMonitor<CouchbaseOptions>.Mock();
         var check = new CouchbaseHealthCheck(serviceProvider, optionsMonitor);
 
         // Act
@@ -35,8 +35,8 @@ public sealed class CouchbaseHealthCheckTests
     public async Task CheckHealthAsync_WhenCancellationTokenIsCancelled_ShouldReturnUnhealthy()
     {
         // Arrange
-        var serviceProvider = Substitute.For<IServiceProvider>();
-        var optionsMonitor = Substitute.For<IOptionsMonitor<CouchbaseOptions>>();
+        var serviceProvider = IServiceProvider.Mock();
+        var optionsMonitor = IOptionsMonitor<CouchbaseOptions>.Mock();
 
         var check = new CouchbaseHealthCheck(serviceProvider, optionsMonitor);
         var context = new HealthCheckContext
@@ -60,8 +60,8 @@ public sealed class CouchbaseHealthCheckTests
     public async Task CheckHealthAsync_WhenOptionsAreNull_ShouldReturnUnhealthy()
     {
         // Arrange
-        var serviceProvider = Substitute.For<IServiceProvider>();
-        var optionsMonitor = Substitute.For<IOptionsMonitor<CouchbaseOptions>>();
+        var serviceProvider = IServiceProvider.Mock();
+        var optionsMonitor = IOptionsMonitor<CouchbaseOptions>.Mock();
 
         var check = new CouchbaseHealthCheck(serviceProvider, optionsMonitor);
         var context = new HealthCheckContext
@@ -95,13 +95,13 @@ public sealed class CouchbaseHealthCheckTests
             },
         };
 
-        var optionsMonitor = Substitute.For<IOptionsMonitor<CouchbaseOptions>>();
+        var optionsMonitor = IOptionsMonitor<CouchbaseOptions>.Mock();
         _ = optionsMonitor.Get(TestName).Returns(options);
 
-        var cluster = Substitute.For<ICluster>();
+        var cluster = ICluster.Mock();
 
         var serviceCollection = new ServiceCollection();
-        _ = serviceCollection.AddKeyedSingleton("test-key", cluster);
+        _ = serviceCollection.AddKeyedSingleton<ICluster>("test-key", cluster);
         var serviceProvider = serviceCollection.BuildServiceProvider();
 
         var healthCheck = new CouchbaseHealthCheck(serviceProvider, optionsMonitor);
@@ -136,13 +136,13 @@ public sealed class CouchbaseHealthCheckTests
             },
         };
 
-        var optionsMonitor = Substitute.For<IOptionsMonitor<CouchbaseOptions>>();
+        var optionsMonitor = IOptionsMonitor<CouchbaseOptions>.Mock();
         _ = optionsMonitor.Get(TestName).Returns(options);
 
-        var cluster = Substitute.For<ICluster>();
+        var cluster = ICluster.Mock();
 
         var serviceCollection = new ServiceCollection();
-        _ = serviceCollection.AddSingleton(cluster);
+        _ = serviceCollection.AddSingleton<ICluster>(cluster);
         var serviceProvider = serviceCollection.BuildServiceProvider();
 
         var healthCheck = new CouchbaseHealthCheck(serviceProvider, optionsMonitor);
@@ -177,13 +177,13 @@ public sealed class CouchbaseHealthCheckTests
             },
         };
 
-        var optionsMonitor = Substitute.For<IOptionsMonitor<CouchbaseOptions>>();
+        var optionsMonitor = IOptionsMonitor<CouchbaseOptions>.Mock();
         _ = optionsMonitor.Get(TestName).Returns(options);
 
-        var cluster = Substitute.For<ICluster>();
+        var cluster = ICluster.Mock();
 
         var serviceCollection = new ServiceCollection();
-        _ = serviceCollection.AddSingleton(cluster);
+        _ = serviceCollection.AddSingleton<ICluster>(cluster);
         var serviceProvider = serviceCollection.BuildServiceProvider();
 
         var healthCheck = new CouchbaseHealthCheck(serviceProvider, optionsMonitor);

--- a/tests/NetEvolve.HealthChecks.Tests.Unit/DB2/DB2HealthCheckTests.cs
+++ b/tests/NetEvolve.HealthChecks.Tests.Unit/DB2/DB2HealthCheckTests.cs
@@ -7,7 +7,7 @@ using Microsoft.Extensions.Diagnostics.HealthChecks;
 using Microsoft.Extensions.Options;
 using NetEvolve.Extensions.TUnit;
 using NetEvolve.HealthChecks.DB2;
-using NSubstitute;
+using TUnit.Mocks;
 
 [TestGroup(nameof(DB2))]
 public sealed class DB2HealthCheckTests
@@ -18,7 +18,7 @@ public sealed class DB2HealthCheckTests
     public async Task CheckHealthAsync_WhenContextNull_ThrowArgumentNullException()
     {
         // Arrange
-        var optionsMonitor = Substitute.For<IOptionsMonitor<DB2Options>>();
+        var optionsMonitor = IOptionsMonitor<DB2Options>.Mock();
         var check = new DB2HealthCheck(optionsMonitor);
 
         // Act
@@ -32,7 +32,7 @@ public sealed class DB2HealthCheckTests
     public async Task CheckHealthAsync_WhenCancellationTokenIsCancelled_ShouldReturnUnhealthy()
     {
         // Arrange
-        var optionsMonitor = Substitute.For<IOptionsMonitor<DB2Options>>();
+        var optionsMonitor = IOptionsMonitor<DB2Options>.Mock();
         var check = new DB2HealthCheck(optionsMonitor);
         var context = new HealthCheckContext
         {
@@ -55,7 +55,7 @@ public sealed class DB2HealthCheckTests
     public async Task CheckHealthAsync_WhenOptionsAreNull_ShouldReturnUnhealthy()
     {
         // Arrange
-        var optionsMonitor = Substitute.For<IOptionsMonitor<DB2Options>>();
+        var optionsMonitor = IOptionsMonitor<DB2Options>.Mock();
         var check = new DB2HealthCheck(optionsMonitor);
         var context = new HealthCheckContext
         {

--- a/tests/NetEvolve.HealthChecks.Tests.Unit/Dapr/DaprHealthCheckTests.cs
+++ b/tests/NetEvolve.HealthChecks.Tests.Unit/Dapr/DaprHealthCheckTests.cs
@@ -9,8 +9,7 @@ using Microsoft.Extensions.Diagnostics.HealthChecks;
 using Microsoft.Extensions.Options;
 using NetEvolve.Extensions.TUnit;
 using NetEvolve.HealthChecks.Dapr;
-using NSubstitute;
-using NSubstitute.ExceptionExtensions;
+using TUnit.Mocks;
 
 [TestGroup(nameof(Dapr))]
 public sealed class DaprHealthCheckTests
@@ -23,10 +22,10 @@ public sealed class DaprHealthCheckTests
         // Arrange
         var services = new ServiceCollection();
 
-        var mockClient = Substitute.For<DaprClient>();
-        _ = mockClient.CheckHealthAsync(Arg.Any<CancellationToken>()).Returns(true);
+        var mockClient = DaprClient.Mock();
+        _ = mockClient.CheckHealthAsync(Any()).Returns(true);
 
-        _ = services.AddSingleton(mockClient);
+        _ = services.AddSingleton<DaprClient>(mockClient);
         _ = services.Configure(TestName, (DaprOptions o) => o.Timeout = 10000);
 
         var serviceProvider = services.BuildServiceProvider();
@@ -55,10 +54,10 @@ public sealed class DaprHealthCheckTests
         // Arrange
         var services = new ServiceCollection();
 
-        var mockClient = Substitute.For<DaprClient>();
-        _ = mockClient.CheckHealthAsync(Arg.Any<CancellationToken>()).Returns(false);
+        var mockClient = DaprClient.Mock();
+        _ = mockClient.CheckHealthAsync(Any()).Returns(false);
 
-        _ = services.AddSingleton(mockClient);
+        _ = services.AddSingleton<DaprClient>(mockClient);
         _ = services.Configure(TestName, (DaprOptions o) => o.Timeout = 0);
 
         var serviceProvider = services.BuildServiceProvider();
@@ -90,16 +89,16 @@ public sealed class DaprHealthCheckTests
         var services = new ServiceCollection();
         var options = new DaprOptions { Timeout = 0 }; // Very short timeout
 
-        var mockClient = Substitute.For<DaprClient>();
+        var mockClient = DaprClient.Mock();
         _ = mockClient
-            .CheckHealthAsync(Arg.Any<CancellationToken>())
-            .Returns(async _ =>
+            .CheckHealthAsync(Any())
+            .Returns(() =>
             {
-                await Task.Delay(1000); // Delay longer than the timeout
+                Thread.Sleep(1000); // Delay longer than the timeout
                 return true;
             });
 
-        _ = services.AddSingleton(mockClient);
+        _ = services.AddSingleton<DaprClient>(mockClient);
         _ = services.Configure(TestName, (DaprOptions o) => o.Timeout = options.Timeout);
 
         var serviceProvider = services.BuildServiceProvider();
@@ -128,12 +127,10 @@ public sealed class DaprHealthCheckTests
         // Arrange
         var services = new ServiceCollection();
 
-        var mockClient = Substitute.For<DaprClient>();
-        _ = mockClient
-            .CheckHealthAsync(Arg.Any<CancellationToken>())
-            .ThrowsAsync(new InvalidOperationException("Test exception"));
+        var mockClient = DaprClient.Mock();
+        _ = mockClient.CheckHealthAsync(Any()).Throws(new InvalidOperationException("Test exception"));
 
-        _ = services.AddSingleton(mockClient);
+        _ = services.AddSingleton<DaprClient>(mockClient);
         _ = services.Configure(TestName, (DaprOptions o) => o.Timeout = 10000);
 
         var serviceProvider = services.BuildServiceProvider();
@@ -166,10 +163,10 @@ public sealed class DaprHealthCheckTests
         var services = new ServiceCollection();
         var options = new DaprOptions { Timeout = 100 };
 
-        var mockClient = Substitute.For<DaprClient>();
-        _ = mockClient.CheckHealthAsync(Arg.Any<CancellationToken>()).Returns(true);
+        var mockClient = DaprClient.Mock();
+        _ = mockClient.CheckHealthAsync(Any()).Returns(true);
 
-        _ = services.AddSingleton(mockClient);
+        _ = services.AddSingleton<DaprClient>(mockClient);
         _ = services.Configure(TestName, (DaprOptions o) => o.Timeout = options.Timeout);
 
         var serviceProvider = services.BuildServiceProvider();
@@ -203,13 +200,15 @@ public sealed class DaprHealthCheckTests
 
         var options = new DaprOptions { KeyedService = serviceKey, Timeout = 100 };
 
-        var optionsMonitor = Substitute.For<IOptionsMonitor<DaprOptions>>();
+        var optionsMonitor = IOptionsMonitor<DaprOptions>.Mock();
         _ = optionsMonitor.Get(TestName).Returns(options);
 
-        var mockClient = Substitute.For<DaprClient>();
-        _ = mockClient.CheckHealthAsync(Arg.Any<CancellationToken>()).Returns(true);
+        var mockClient = DaprClient.Mock();
+        _ = mockClient.CheckHealthAsync(Any()).Returns(true);
 
-        var serviceProvider = new ServiceCollection().AddKeyedSingleton(serviceKey, mockClient).BuildServiceProvider();
+        var serviceProvider = new ServiceCollection()
+            .AddKeyedSingleton<DaprClient>(serviceKey, mockClient)
+            .BuildServiceProvider();
 
         var healthCheck = new DaprHealthCheck(serviceProvider, optionsMonitor);
         var context = new HealthCheckContext
@@ -236,18 +235,18 @@ public sealed class DaprHealthCheckTests
 
         var options = new DaprOptions { KeyedService = serviceKey, Timeout = 100 };
 
-        var optionsMonitor = Substitute.For<IOptionsMonitor<DaprOptions>>();
+        var optionsMonitor = IOptionsMonitor<DaprOptions>.Mock();
         _ = optionsMonitor.Get(TestName).Returns(options);
 
-        var defaultClient = Substitute.For<DaprClient>();
-        _ = defaultClient.CheckHealthAsync(Arg.Any<CancellationToken>()).Returns(false); // Returns unhealthy
+        var defaultClient = DaprClient.Mock();
+        _ = defaultClient.CheckHealthAsync(Any()).Returns(false); // Returns unhealthy
 
-        var keyedClient = Substitute.For<DaprClient>();
-        _ = keyedClient.CheckHealthAsync(Arg.Any<CancellationToken>()).Returns(true); // Returns healthy
+        var keyedClient = DaprClient.Mock();
+        _ = keyedClient.CheckHealthAsync(Any()).Returns(true); // Returns healthy
 
         var serviceProvider = new ServiceCollection()
-            .AddSingleton(defaultClient)
-            .AddKeyedSingleton(serviceKey, keyedClient)
+            .AddSingleton<DaprClient>(defaultClient)
+            .AddKeyedSingleton<DaprClient>(serviceKey, keyedClient)
             .BuildServiceProvider();
 
         var healthCheck = new DaprHealthCheck(serviceProvider, optionsMonitor);

--- a/tests/NetEvolve.HealthChecks.Tests.Unit/DuckDB/DuckDBHealthCheckTests.cs
+++ b/tests/NetEvolve.HealthChecks.Tests.Unit/DuckDB/DuckDBHealthCheckTests.cs
@@ -7,7 +7,7 @@ using Microsoft.Extensions.Diagnostics.HealthChecks;
 using Microsoft.Extensions.Options;
 using NetEvolve.Extensions.TUnit;
 using NetEvolve.HealthChecks.DuckDB;
-using NSubstitute;
+using TUnit.Mocks;
 
 [TestGroup(nameof(DuckDB))]
 public sealed class DuckDBHealthCheckTests
@@ -18,7 +18,7 @@ public sealed class DuckDBHealthCheckTests
     public async Task CheckHealthAsync_WhenContextNull_ThrowArgumentNullException()
     {
         // Arrange
-        var optionsMonitor = Substitute.For<IOptionsMonitor<DuckDBOptions>>();
+        var optionsMonitor = IOptionsMonitor<DuckDBOptions>.Mock();
         var check = new DuckDBHealthCheck(optionsMonitor);
 
         // Act
@@ -32,7 +32,7 @@ public sealed class DuckDBHealthCheckTests
     public async Task CheckHealthAsync_WhenCancellationTokenIsCancelled_ShouldReturnUnhealthy()
     {
         // Arrange
-        var optionsMonitor = Substitute.For<IOptionsMonitor<DuckDBOptions>>();
+        var optionsMonitor = IOptionsMonitor<DuckDBOptions>.Mock();
         var check = new DuckDBHealthCheck(optionsMonitor);
         var context = new HealthCheckContext
         {
@@ -55,7 +55,7 @@ public sealed class DuckDBHealthCheckTests
     public async Task CheckHealthAsync_WhenOptionsAreNull_ShouldReturnUnhealthy()
     {
         // Arrange
-        var optionsMonitor = Substitute.For<IOptionsMonitor<DuckDBOptions>>();
+        var optionsMonitor = IOptionsMonitor<DuckDBOptions>.Mock();
         var check = new DuckDBHealthCheck(optionsMonitor);
         var context = new HealthCheckContext
         {

--- a/tests/NetEvolve.HealthChecks.Tests.Unit/Firebird/FirebirdHealthCheckTests.cs
+++ b/tests/NetEvolve.HealthChecks.Tests.Unit/Firebird/FirebirdHealthCheckTests.cs
@@ -5,7 +5,7 @@ using Microsoft.Extensions.Diagnostics.HealthChecks;
 using Microsoft.Extensions.Options;
 using NetEvolve.Extensions.TUnit;
 using NetEvolve.HealthChecks.Firebird;
-using NSubstitute;
+using TUnit.Mocks;
 
 [TestGroup(nameof(Firebird))]
 public sealed class FirebirdHealthCheckTests
@@ -16,7 +16,7 @@ public sealed class FirebirdHealthCheckTests
     public async Task CheckHealthAsync_WhenContextNull_ThrowArgumentNullException()
     {
         // Arrange
-        var optionsMonitor = Substitute.For<IOptionsMonitor<FirebirdOptions>>();
+        var optionsMonitor = IOptionsMonitor<FirebirdOptions>.Mock();
         var check = new FirebirdHealthCheck(optionsMonitor);
 
         // Act
@@ -30,7 +30,7 @@ public sealed class FirebirdHealthCheckTests
     public async Task CheckHealthAsync_WhenCancellationTokenIsCancelled_ShouldReturnUnhealthy()
     {
         // Arrange
-        var optionsMonitor = Substitute.For<IOptionsMonitor<FirebirdOptions>>();
+        var optionsMonitor = IOptionsMonitor<FirebirdOptions>.Mock();
         var check = new FirebirdHealthCheck(optionsMonitor);
         var context = new HealthCheckContext
         {
@@ -53,7 +53,7 @@ public sealed class FirebirdHealthCheckTests
     public async Task CheckHealthAsync_WhenOptionsAreNull_ShouldReturnUnhealthy()
     {
         // Arrange
-        var optionsMonitor = Substitute.For<IOptionsMonitor<FirebirdOptions>>();
+        var optionsMonitor = IOptionsMonitor<FirebirdOptions>.Mock();
         var check = new FirebirdHealthCheck(optionsMonitor);
         var context = new HealthCheckContext
         {

--- a/tests/NetEvolve.HealthChecks.Tests.Unit/GCP.BigQuery/BigQueryHealthCheckTests.cs
+++ b/tests/NetEvolve.HealthChecks.Tests.Unit/GCP.BigQuery/BigQueryHealthCheckTests.cs
@@ -7,7 +7,7 @@ using Microsoft.Extensions.Diagnostics.HealthChecks;
 using Microsoft.Extensions.Options;
 using NetEvolve.Extensions.TUnit;
 using NetEvolve.HealthChecks.GCP.BigQuery;
-using NSubstitute;
+using TUnit.Mocks;
 
 [TestGroup($"GCP.{nameof(BigQuery)}")]
 public sealed class BigQueryHealthCheckTests
@@ -18,8 +18,8 @@ public sealed class BigQueryHealthCheckTests
     public async Task CheckHealthAsync_WhenContextNull_ThrowArgumentNullException()
     {
         // Arrange
-        var optionsMonitor = Substitute.For<IOptionsMonitor<BigQueryOptions>>();
-        var serviceProvider = Substitute.For<IServiceProvider>();
+        var optionsMonitor = IOptionsMonitor<BigQueryOptions>.Mock();
+        var serviceProvider = IServiceProvider.Mock();
         var check = new BigQueryHealthCheck(serviceProvider, optionsMonitor);
 
         // Act
@@ -33,8 +33,8 @@ public sealed class BigQueryHealthCheckTests
     public async Task CheckHealthAsync_WhenCancellationTokenIsCancelled_ShouldReturnUnhealthy()
     {
         // Arrange
-        var optionsMonitor = Substitute.For<IOptionsMonitor<BigQueryOptions>>();
-        var serviceProvider = Substitute.For<IServiceProvider>();
+        var optionsMonitor = IOptionsMonitor<BigQueryOptions>.Mock();
+        var serviceProvider = IServiceProvider.Mock();
         var check = new BigQueryHealthCheck(serviceProvider, optionsMonitor);
         var context = new HealthCheckContext
         {
@@ -57,8 +57,8 @@ public sealed class BigQueryHealthCheckTests
     public async Task CheckHealthAsync_WhenOptionsAreNull_ShouldReturnUnhealthy()
     {
         // Arrange
-        var optionsMonitor = Substitute.For<IOptionsMonitor<BigQueryOptions>>();
-        var serviceProvider = Substitute.For<IServiceProvider>();
+        var optionsMonitor = IOptionsMonitor<BigQueryOptions>.Mock();
+        var serviceProvider = IServiceProvider.Mock();
         var check = new BigQueryHealthCheck(serviceProvider, optionsMonitor);
         var context = new HealthCheckContext
         {

--- a/tests/NetEvolve.HealthChecks.Tests.Unit/GCP.Bigtable/BigtableHealthCheckTests.cs
+++ b/tests/NetEvolve.HealthChecks.Tests.Unit/GCP.Bigtable/BigtableHealthCheckTests.cs
@@ -7,7 +7,7 @@ using Microsoft.Extensions.Diagnostics.HealthChecks;
 using Microsoft.Extensions.Options;
 using NetEvolve.Extensions.TUnit;
 using NetEvolve.HealthChecks.GCP.Bigtable;
-using NSubstitute;
+using TUnit.Mocks;
 
 [TestGroup($"GCP.{nameof(Bigtable)}")]
 public sealed class BigtableHealthCheckTests
@@ -18,8 +18,8 @@ public sealed class BigtableHealthCheckTests
     public async Task CheckHealthAsync_WhenContextNull_ThrowArgumentNullException()
     {
         // Arrange
-        var optionsMonitor = Substitute.For<IOptionsMonitor<BigtableOptions>>();
-        var serviceProvider = Substitute.For<IServiceProvider>();
+        var optionsMonitor = IOptionsMonitor<BigtableOptions>.Mock();
+        var serviceProvider = IServiceProvider.Mock();
         var check = new BigtableHealthCheck(serviceProvider, optionsMonitor);
 
         // Act
@@ -33,8 +33,8 @@ public sealed class BigtableHealthCheckTests
     public async Task CheckHealthAsync_WhenCancellationTokenIsCancelled_ShouldReturnUnhealthy()
     {
         // Arrange
-        var optionsMonitor = Substitute.For<IOptionsMonitor<BigtableOptions>>();
-        var serviceProvider = Substitute.For<IServiceProvider>();
+        var optionsMonitor = IOptionsMonitor<BigtableOptions>.Mock();
+        var serviceProvider = IServiceProvider.Mock();
         var check = new BigtableHealthCheck(serviceProvider, optionsMonitor);
         var context = new HealthCheckContext
         {
@@ -57,8 +57,8 @@ public sealed class BigtableHealthCheckTests
     public async Task CheckHealthAsync_WhenOptionsAreNull_ShouldReturnUnhealthy()
     {
         // Arrange
-        var optionsMonitor = Substitute.For<IOptionsMonitor<BigtableOptions>>();
-        var serviceProvider = Substitute.For<IServiceProvider>();
+        var optionsMonitor = IOptionsMonitor<BigtableOptions>.Mock();
+        var serviceProvider = IServiceProvider.Mock();
         var check = new BigtableHealthCheck(serviceProvider, optionsMonitor);
         var context = new HealthCheckContext
         {

--- a/tests/NetEvolve.HealthChecks.Tests.Unit/GCP.Firestore/FirestoreHealthCheckTests.cs
+++ b/tests/NetEvolve.HealthChecks.Tests.Unit/GCP.Firestore/FirestoreHealthCheckTests.cs
@@ -7,7 +7,7 @@ using Microsoft.Extensions.Diagnostics.HealthChecks;
 using Microsoft.Extensions.Options;
 using NetEvolve.Extensions.TUnit;
 using NetEvolve.HealthChecks.GCP.Firestore;
-using NSubstitute;
+using TUnit.Mocks;
 
 [TestGroup($"GCP.{nameof(Firestore)}")]
 public sealed class FirestoreHealthCheckTests
@@ -18,8 +18,8 @@ public sealed class FirestoreHealthCheckTests
     public async Task CheckHealthAsync_WhenContextNull_ThrowArgumentNullException()
     {
         // Arrange
-        var optionsMonitor = Substitute.For<IOptionsMonitor<FirestoreOptions>>();
-        var serviceProvider = Substitute.For<IServiceProvider>();
+        var optionsMonitor = IOptionsMonitor<FirestoreOptions>.Mock();
+        var serviceProvider = IServiceProvider.Mock();
         var check = new FirestoreHealthCheck(serviceProvider, optionsMonitor);
 
         // Act
@@ -33,8 +33,8 @@ public sealed class FirestoreHealthCheckTests
     public async Task CheckHealthAsync_WhenCancellationTokenIsCancelled_ShouldReturnUnhealthy()
     {
         // Arrange
-        var optionsMonitor = Substitute.For<IOptionsMonitor<FirestoreOptions>>();
-        var serviceProvider = Substitute.For<IServiceProvider>();
+        var optionsMonitor = IOptionsMonitor<FirestoreOptions>.Mock();
+        var serviceProvider = IServiceProvider.Mock();
         var check = new FirestoreHealthCheck(serviceProvider, optionsMonitor);
         var context = new HealthCheckContext
         {
@@ -57,8 +57,8 @@ public sealed class FirestoreHealthCheckTests
     public async Task CheckHealthAsync_WhenOptionsAreNull_ShouldReturnUnhealthy()
     {
         // Arrange
-        var optionsMonitor = Substitute.For<IOptionsMonitor<FirestoreOptions>>();
-        var serviceProvider = Substitute.For<IServiceProvider>();
+        var optionsMonitor = IOptionsMonitor<FirestoreOptions>.Mock();
+        var serviceProvider = IServiceProvider.Mock();
         var check = new FirestoreHealthCheck(serviceProvider, optionsMonitor);
         var context = new HealthCheckContext
         {

--- a/tests/NetEvolve.HealthChecks.Tests.Unit/GCP.PubSub/PubSubHealthCheckTests.cs
+++ b/tests/NetEvolve.HealthChecks.Tests.Unit/GCP.PubSub/PubSubHealthCheckTests.cs
@@ -7,7 +7,7 @@ using Microsoft.Extensions.Diagnostics.HealthChecks;
 using Microsoft.Extensions.Options;
 using NetEvolve.Extensions.TUnit;
 using NetEvolve.HealthChecks.GCP.PubSub;
-using NSubstitute;
+using TUnit.Mocks;
 
 [TestGroup($"GCP.{nameof(PubSub)}")]
 public sealed class PubSubHealthCheckTests
@@ -18,8 +18,8 @@ public sealed class PubSubHealthCheckTests
     public async Task CheckHealthAsync_WhenContextNull_ThrowArgumentNullException()
     {
         // Arrange
-        var optionsMonitor = Substitute.For<IOptionsMonitor<PubSubOptions>>();
-        var serviceProvider = Substitute.For<IServiceProvider>();
+        var optionsMonitor = IOptionsMonitor<PubSubOptions>.Mock();
+        var serviceProvider = IServiceProvider.Mock();
         var check = new PubSubHealthCheck(serviceProvider, optionsMonitor);
 
         // Act
@@ -33,8 +33,8 @@ public sealed class PubSubHealthCheckTests
     public async Task CheckHealthAsync_WhenCancellationTokenIsCancelled_ShouldReturnUnhealthy()
     {
         // Arrange
-        var optionsMonitor = Substitute.For<IOptionsMonitor<PubSubOptions>>();
-        var serviceProvider = Substitute.For<IServiceProvider>();
+        var optionsMonitor = IOptionsMonitor<PubSubOptions>.Mock();
+        var serviceProvider = IServiceProvider.Mock();
         var check = new PubSubHealthCheck(serviceProvider, optionsMonitor);
         var context = new HealthCheckContext
         {
@@ -57,8 +57,8 @@ public sealed class PubSubHealthCheckTests
     public async Task CheckHealthAsync_WhenOptionsAreNull_ShouldReturnUnhealthy()
     {
         // Arrange
-        var optionsMonitor = Substitute.For<IOptionsMonitor<PubSubOptions>>();
-        var serviceProvider = Substitute.For<IServiceProvider>();
+        var optionsMonitor = IOptionsMonitor<PubSubOptions>.Mock();
+        var serviceProvider = IServiceProvider.Mock();
         var check = new PubSubHealthCheck(serviceProvider, optionsMonitor);
         var context = new HealthCheckContext
         {

--- a/tests/NetEvolve.HealthChecks.Tests.Unit/InfluxDB/InfluxDBHealthCheckTests.cs
+++ b/tests/NetEvolve.HealthChecks.Tests.Unit/InfluxDB/InfluxDBHealthCheckTests.cs
@@ -9,7 +9,7 @@ using Microsoft.Extensions.Diagnostics.HealthChecks;
 using Microsoft.Extensions.Options;
 using NetEvolve.Extensions.TUnit;
 using NetEvolve.HealthChecks.InfluxDB;
-using NSubstitute;
+using TUnit.Mocks;
 
 [TestGroup(nameof(InfluxDB))]
 public sealed class InfluxDBHealthCheckTests
@@ -20,8 +20,8 @@ public sealed class InfluxDBHealthCheckTests
     public async Task CheckHealthAsync_WhenContextNull_ThrowArgumentNullException()
     {
         // Arrange
-        var serviceProvider = Substitute.For<IServiceProvider>();
-        var optionsMonitor = Substitute.For<IOptionsMonitor<InfluxDBOptions>>();
+        var serviceProvider = IServiceProvider.Mock();
+        var optionsMonitor = IOptionsMonitor<InfluxDBOptions>.Mock();
         var check = new InfluxDBHealthCheck(serviceProvider, optionsMonitor);
 
         // Act
@@ -35,8 +35,8 @@ public sealed class InfluxDBHealthCheckTests
     public async Task CheckHealthAsync_WhenCancellationTokenIsCancelled_ShouldReturnUnhealthy()
     {
         // Arrange
-        var serviceProvider = Substitute.For<IServiceProvider>();
-        var optionsMonitor = Substitute.For<IOptionsMonitor<InfluxDBOptions>>();
+        var serviceProvider = IServiceProvider.Mock();
+        var optionsMonitor = IOptionsMonitor<InfluxDBOptions>.Mock();
 
         var check = new InfluxDBHealthCheck(serviceProvider, optionsMonitor);
         var context = new HealthCheckContext
@@ -60,8 +60,8 @@ public sealed class InfluxDBHealthCheckTests
     public async Task CheckHealthAsync_WhenOptionsAreNull_ShouldReturnUnhealthy()
     {
         // Arrange
-        var serviceProvider = Substitute.For<IServiceProvider>();
-        var optionsMonitor = Substitute.For<IOptionsMonitor<InfluxDBOptions>>();
+        var serviceProvider = IServiceProvider.Mock();
+        var optionsMonitor = IOptionsMonitor<InfluxDBOptions>.Mock();
 
         var check = new InfluxDBHealthCheck(serviceProvider, optionsMonitor);
         var context = new HealthCheckContext
@@ -95,13 +95,13 @@ public sealed class InfluxDBHealthCheckTests
             },
         };
 
-        var optionsMonitor = Substitute.For<IOptionsMonitor<InfluxDBOptions>>();
+        var optionsMonitor = IOptionsMonitor<InfluxDBOptions>.Mock();
         _ = optionsMonitor.Get(TestName).Returns(options);
 
-        var client = Substitute.For<IInfluxDBClient>();
+        var client = IInfluxDBClient.Mock();
 
         var serviceCollection = new ServiceCollection();
-        _ = serviceCollection.AddKeyedSingleton("test-key", client);
+        _ = serviceCollection.AddKeyedSingleton<IInfluxDBClient>("test-key", client);
         var serviceProvider = serviceCollection.BuildServiceProvider();
 
         var healthCheck = new InfluxDBHealthCheck(serviceProvider, optionsMonitor);
@@ -136,13 +136,13 @@ public sealed class InfluxDBHealthCheckTests
             },
         };
 
-        var optionsMonitor = Substitute.For<IOptionsMonitor<InfluxDBOptions>>();
+        var optionsMonitor = IOptionsMonitor<InfluxDBOptions>.Mock();
         _ = optionsMonitor.Get(TestName).Returns(options);
 
-        var client = Substitute.For<IInfluxDBClient>();
+        var client = IInfluxDBClient.Mock();
 
         var serviceCollection = new ServiceCollection();
-        _ = serviceCollection.AddSingleton(client);
+        _ = serviceCollection.AddSingleton<IInfluxDBClient>(client);
         var serviceProvider = serviceCollection.BuildServiceProvider();
 
         var healthCheck = new InfluxDBHealthCheck(serviceProvider, optionsMonitor);
@@ -177,13 +177,13 @@ public sealed class InfluxDBHealthCheckTests
             },
         };
 
-        var optionsMonitor = Substitute.For<IOptionsMonitor<InfluxDBOptions>>();
+        var optionsMonitor = IOptionsMonitor<InfluxDBOptions>.Mock();
         _ = optionsMonitor.Get(TestName).Returns(options);
 
-        var client = Substitute.For<IInfluxDBClient>();
+        var client = IInfluxDBClient.Mock();
 
         var serviceCollection = new ServiceCollection();
-        _ = serviceCollection.AddSingleton(client);
+        _ = serviceCollection.AddSingleton<IInfluxDBClient>(client);
         var serviceProvider = serviceCollection.BuildServiceProvider();
 
         var healthCheck = new InfluxDBHealthCheck(serviceProvider, optionsMonitor);

--- a/tests/NetEvolve.HealthChecks.Tests.Unit/JanusGraph/JanusGraphHealthCheckTests.cs
+++ b/tests/NetEvolve.HealthChecks.Tests.Unit/JanusGraph/JanusGraphHealthCheckTests.cs
@@ -9,7 +9,7 @@ using Microsoft.Extensions.Diagnostics.HealthChecks;
 using Microsoft.Extensions.Options;
 using NetEvolve.Extensions.TUnit;
 using NetEvolve.HealthChecks.JanusGraph;
-using NSubstitute;
+using TUnit.Mocks;
 
 [TestGroup(nameof(JanusGraph))]
 public sealed class JanusGraphHealthCheckTests
@@ -20,8 +20,8 @@ public sealed class JanusGraphHealthCheckTests
     public async Task CheckHealthAsync_WhenContextNull_ThrowArgumentNullException()
     {
         // Arrange
-        var serviceProvider = Substitute.For<IServiceProvider>();
-        var optionsMonitor = Substitute.For<IOptionsMonitor<JanusGraphOptions>>();
+        var serviceProvider = IServiceProvider.Mock();
+        var optionsMonitor = IOptionsMonitor<JanusGraphOptions>.Mock();
         var check = new JanusGraphHealthCheck(serviceProvider, optionsMonitor);
 
         // Act
@@ -35,8 +35,8 @@ public sealed class JanusGraphHealthCheckTests
     public async Task CheckHealthAsync_WhenCancellationTokenIsCancelled_ShouldReturnUnhealthy()
     {
         // Arrange
-        var serviceProvider = Substitute.For<IServiceProvider>();
-        var optionsMonitor = Substitute.For<IOptionsMonitor<JanusGraphOptions>>();
+        var serviceProvider = IServiceProvider.Mock();
+        var optionsMonitor = IOptionsMonitor<JanusGraphOptions>.Mock();
 
         var check = new JanusGraphHealthCheck(serviceProvider, optionsMonitor);
         var context = new HealthCheckContext
@@ -60,8 +60,8 @@ public sealed class JanusGraphHealthCheckTests
     public async Task CheckHealthAsync_WhenOptionsAreNull_ShouldReturnUnhealthy()
     {
         // Arrange
-        var serviceProvider = Substitute.For<IServiceProvider>();
-        var optionsMonitor = Substitute.For<IOptionsMonitor<JanusGraphOptions>>();
+        var serviceProvider = IServiceProvider.Mock();
+        var optionsMonitor = IOptionsMonitor<JanusGraphOptions>.Mock();
 
         var check = new JanusGraphHealthCheck(serviceProvider, optionsMonitor);
         var context = new HealthCheckContext
@@ -95,13 +95,13 @@ public sealed class JanusGraphHealthCheckTests
             },
         };
 
-        var optionsMonitor = Substitute.For<IOptionsMonitor<JanusGraphOptions>>();
+        var optionsMonitor = IOptionsMonitor<JanusGraphOptions>.Mock();
         _ = optionsMonitor.Get(TestName).Returns(options);
 
-        var client = Substitute.For<IGremlinClient>();
+        var client = IGremlinClient.Mock();
 
         var serviceCollection = new ServiceCollection();
-        _ = serviceCollection.AddKeyedSingleton("test-key", client);
+        _ = serviceCollection.AddKeyedSingleton<IGremlinClient>("test-key", client);
         var serviceProvider = serviceCollection.BuildServiceProvider();
 
         var healthCheck = new JanusGraphHealthCheck(serviceProvider, optionsMonitor);
@@ -136,13 +136,13 @@ public sealed class JanusGraphHealthCheckTests
             },
         };
 
-        var optionsMonitor = Substitute.For<IOptionsMonitor<JanusGraphOptions>>();
+        var optionsMonitor = IOptionsMonitor<JanusGraphOptions>.Mock();
         _ = optionsMonitor.Get(TestName).Returns(options);
 
-        var client = Substitute.For<IGremlinClient>();
+        var client = IGremlinClient.Mock();
 
         var serviceCollection = new ServiceCollection();
-        _ = serviceCollection.AddSingleton(client);
+        _ = serviceCollection.AddSingleton<IGremlinClient>(client);
         var serviceProvider = serviceCollection.BuildServiceProvider();
 
         var healthCheck = new JanusGraphHealthCheck(serviceProvider, optionsMonitor);
@@ -177,13 +177,13 @@ public sealed class JanusGraphHealthCheckTests
             },
         };
 
-        var optionsMonitor = Substitute.For<IOptionsMonitor<JanusGraphOptions>>();
+        var optionsMonitor = IOptionsMonitor<JanusGraphOptions>.Mock();
         _ = optionsMonitor.Get(TestName).Returns(options);
 
-        var client = Substitute.For<IGremlinClient>();
+        var client = IGremlinClient.Mock();
 
         var serviceCollection = new ServiceCollection();
-        _ = serviceCollection.AddSingleton(client);
+        _ = serviceCollection.AddSingleton<IGremlinClient>(client);
         var serviceProvider = serviceCollection.BuildServiceProvider();
 
         var healthCheck = new JanusGraphHealthCheck(serviceProvider, optionsMonitor);

--- a/tests/NetEvolve.HealthChecks.Tests.Unit/Keycloak/KeycloakHealthCheckTests.cs
+++ b/tests/NetEvolve.HealthChecks.Tests.Unit/Keycloak/KeycloakHealthCheckTests.cs
@@ -9,7 +9,7 @@ using Microsoft.Extensions.Diagnostics.HealthChecks;
 using Microsoft.Extensions.Options;
 using NetEvolve.Extensions.TUnit;
 using NetEvolve.HealthChecks.Keycloak;
-using NSubstitute;
+using TUnit.Mocks;
 
 [TestGroup(nameof(Keycloak))]
 public sealed class KeycloakHealthCheckTests
@@ -20,8 +20,8 @@ public sealed class KeycloakHealthCheckTests
     public async Task CheckHealthAsync_WhenContextNull_ThrowArgumentNullException()
     {
         // Arrange
-        var serviceProvider = Substitute.For<IServiceProvider>();
-        var optionsMonitor = Substitute.For<IOptionsMonitor<NetEvolve.HealthChecks.Keycloak.KeycloakOptions>>();
+        var serviceProvider = IServiceProvider.Mock();
+        var optionsMonitor = IOptionsMonitor<NetEvolve.HealthChecks.Keycloak.KeycloakOptions>.Mock();
         var check = new KeycloakHealthCheck(serviceProvider, optionsMonitor);
 
         // Act
@@ -36,8 +36,8 @@ public sealed class KeycloakHealthCheckTests
     {
         // Arrange
 
-        var serviceProvider = Substitute.For<IServiceProvider>();
-        var optionsMonitor = Substitute.For<IOptionsMonitor<NetEvolve.HealthChecks.Keycloak.KeycloakOptions>>();
+        var serviceProvider = IServiceProvider.Mock();
+        var optionsMonitor = IOptionsMonitor<NetEvolve.HealthChecks.Keycloak.KeycloakOptions>.Mock();
 
         var check = new KeycloakHealthCheck(serviceProvider, optionsMonitor);
         var context = new HealthCheckContext
@@ -62,8 +62,8 @@ public sealed class KeycloakHealthCheckTests
     {
         // Arrange
 
-        var serviceProvider = Substitute.For<IServiceProvider>();
-        var optionsMonitor = Substitute.For<IOptionsMonitor<NetEvolve.HealthChecks.Keycloak.KeycloakOptions>>();
+        var serviceProvider = IServiceProvider.Mock();
+        var optionsMonitor = IOptionsMonitor<NetEvolve.HealthChecks.Keycloak.KeycloakOptions>.Mock();
 
         var check = new KeycloakHealthCheck(serviceProvider, optionsMonitor);
         var context = new HealthCheckContext
@@ -99,7 +99,7 @@ public sealed class KeycloakHealthCheckTests
             },
         };
 
-        var optionsMonitor = Substitute.For<IOptionsMonitor<NetEvolve.HealthChecks.Keycloak.KeycloakOptions>>();
+        var optionsMonitor = IOptionsMonitor<NetEvolve.HealthChecks.Keycloak.KeycloakOptions>.Mock();
         _ = optionsMonitor.Get(TestName).Returns(options);
 
         // Setup client mock that returns success
@@ -142,7 +142,7 @@ public sealed class KeycloakHealthCheckTests
             },
         };
 
-        var optionsMonitor = Substitute.For<IOptionsMonitor<NetEvolve.HealthChecks.Keycloak.KeycloakOptions>>();
+        var optionsMonitor = IOptionsMonitor<NetEvolve.HealthChecks.Keycloak.KeycloakOptions>.Mock();
         _ = optionsMonitor.Get(TestName).Returns(options);
 
         // Setup connection mock that returns success
@@ -186,7 +186,7 @@ public sealed class KeycloakHealthCheckTests
             },
         };
 
-        var optionsMonitor = Substitute.For<IOptionsMonitor<NetEvolve.HealthChecks.Keycloak.KeycloakOptions>>();
+        var optionsMonitor = IOptionsMonitor<NetEvolve.HealthChecks.Keycloak.KeycloakOptions>.Mock();
         _ = optionsMonitor.Get(TestName).Returns(options);
 
         // Setup connection mock that throws an exception

--- a/tests/NetEvolve.HealthChecks.Tests.Unit/Kubernetes/KubernetesHealthCheckTests.cs
+++ b/tests/NetEvolve.HealthChecks.Tests.Unit/Kubernetes/KubernetesHealthCheckTests.cs
@@ -7,7 +7,7 @@ using Microsoft.Extensions.Diagnostics.HealthChecks;
 using Microsoft.Extensions.Options;
 using NetEvolve.Extensions.TUnit;
 using NetEvolve.HealthChecks.Kubernetes;
-using NSubstitute;
+using TUnit.Mocks;
 
 [TestGroup(nameof(Kubernetes))]
 public sealed class KubernetesHealthCheckTests
@@ -18,8 +18,8 @@ public sealed class KubernetesHealthCheckTests
     public async Task CheckHealthAsync_WhenContextNull_ThrowArgumentNullException()
     {
         // Arrange
-        var optionsMonitor = Substitute.For<IOptionsMonitor<KubernetesOptions>>();
-        var serviceProvider = Substitute.For<IServiceProvider>();
+        var optionsMonitor = IOptionsMonitor<KubernetesOptions>.Mock();
+        var serviceProvider = IServiceProvider.Mock();
         var check = new KubernetesHealthCheck(serviceProvider, optionsMonitor);
 
         // Act
@@ -33,8 +33,8 @@ public sealed class KubernetesHealthCheckTests
     public async Task CheckHealthAsync_WhenCancellationTokenIsCancelled_ShouldReturnUnhealthy()
     {
         // Arrange
-        var optionsMonitor = Substitute.For<IOptionsMonitor<KubernetesOptions>>();
-        var serviceProvider = Substitute.For<IServiceProvider>();
+        var optionsMonitor = IOptionsMonitor<KubernetesOptions>.Mock();
+        var serviceProvider = IServiceProvider.Mock();
         var check = new KubernetesHealthCheck(serviceProvider, optionsMonitor);
         var context = new HealthCheckContext
         {
@@ -57,8 +57,8 @@ public sealed class KubernetesHealthCheckTests
     public async Task CheckHealthAsync_WhenOptionsAreNull_ShouldReturnUnhealthy()
     {
         // Arrange
-        var optionsMonitor = Substitute.For<IOptionsMonitor<KubernetesOptions>>();
-        var serviceProvider = Substitute.For<IServiceProvider>();
+        var optionsMonitor = IOptionsMonitor<KubernetesOptions>.Mock();
+        var serviceProvider = IServiceProvider.Mock();
         var check = new KubernetesHealthCheck(serviceProvider, optionsMonitor);
         var context = new HealthCheckContext
         {

--- a/tests/NetEvolve.HealthChecks.Tests.Unit/KurrentDb/KurrentDbHealthCheckTests.cs
+++ b/tests/NetEvolve.HealthChecks.Tests.Unit/KurrentDb/KurrentDbHealthCheckTests.cs
@@ -7,7 +7,7 @@ using Microsoft.Extensions.Diagnostics.HealthChecks;
 using Microsoft.Extensions.Options;
 using NetEvolve.Extensions.TUnit;
 using NetEvolve.HealthChecks.KurrentDb;
-using NSubstitute;
+using TUnit.Mocks;
 
 [TestGroup(nameof(KurrentDb))]
 public sealed class KurrentDbHealthCheckTests
@@ -18,8 +18,8 @@ public sealed class KurrentDbHealthCheckTests
     public async Task CheckHealthAsync_WhenContextNull_ThrowArgumentNullException()
     {
         // Arrange
-        var serviceProvider = Substitute.For<IServiceProvider>();
-        var optionsMonitor = Substitute.For<IOptionsMonitor<KurrentDbOptions>>();
+        var serviceProvider = IServiceProvider.Mock();
+        var optionsMonitor = IOptionsMonitor<KurrentDbOptions>.Mock();
         var check = new KurrentDbHealthCheck(serviceProvider, optionsMonitor);
 
         // Act
@@ -33,8 +33,8 @@ public sealed class KurrentDbHealthCheckTests
     public async Task CheckHealthAsync_WhenCancellationTokenIsCancelled_ShouldReturnUnhealthy()
     {
         // Arrange
-        var serviceProvider = Substitute.For<IServiceProvider>();
-        var optionsMonitor = Substitute.For<IOptionsMonitor<KurrentDbOptions>>();
+        var serviceProvider = IServiceProvider.Mock();
+        var optionsMonitor = IOptionsMonitor<KurrentDbOptions>.Mock();
 
         var check = new KurrentDbHealthCheck(serviceProvider, optionsMonitor);
         var context = new HealthCheckContext
@@ -58,8 +58,8 @@ public sealed class KurrentDbHealthCheckTests
     public async Task CheckHealthAsync_WhenOptionsAreNull_ShouldReturnUnhealthy()
     {
         // Arrange
-        var serviceProvider = Substitute.For<IServiceProvider>();
-        var optionsMonitor = Substitute.For<IOptionsMonitor<KurrentDbOptions>>();
+        var serviceProvider = IServiceProvider.Mock();
+        var optionsMonitor = IOptionsMonitor<KurrentDbOptions>.Mock();
 
         var check = new KurrentDbHealthCheck(serviceProvider, optionsMonitor);
         var context = new HealthCheckContext

--- a/tests/NetEvolve.HealthChecks.Tests.Unit/LiteDB/LiteDBHealthCheckTests.cs
+++ b/tests/NetEvolve.HealthChecks.Tests.Unit/LiteDB/LiteDBHealthCheckTests.cs
@@ -7,7 +7,7 @@ using Microsoft.Extensions.Diagnostics.HealthChecks;
 using Microsoft.Extensions.Options;
 using NetEvolve.Extensions.TUnit;
 using NetEvolve.HealthChecks.LiteDB;
-using NSubstitute;
+using TUnit.Mocks;
 
 [TestGroup(nameof(LiteDB))]
 public sealed class LiteDBHealthCheckTests
@@ -18,8 +18,8 @@ public sealed class LiteDBHealthCheckTests
     public async Task CheckHealthAsync_WhenContextNull_ThrowArgumentNullException()
     {
         // Arrange
-        var optionsMonitor = Substitute.For<IOptionsMonitor<LiteDBOptions>>();
-        var serviceProvider = Substitute.For<IServiceProvider>();
+        var optionsMonitor = IOptionsMonitor<LiteDBOptions>.Mock();
+        var serviceProvider = IServiceProvider.Mock();
         var check = new LiteDBHealthCheck(serviceProvider, optionsMonitor);
 
         // Act
@@ -33,8 +33,8 @@ public sealed class LiteDBHealthCheckTests
     public async Task CheckHealthAsync_WhenCancellationTokenIsCancelled_ShouldReturnUnhealthy()
     {
         // Arrange
-        var optionsMonitor = Substitute.For<IOptionsMonitor<LiteDBOptions>>();
-        var serviceProvider = Substitute.For<IServiceProvider>();
+        var optionsMonitor = IOptionsMonitor<LiteDBOptions>.Mock();
+        var serviceProvider = IServiceProvider.Mock();
         var check = new LiteDBHealthCheck(serviceProvider, optionsMonitor);
         var context = new HealthCheckContext
         {
@@ -57,8 +57,8 @@ public sealed class LiteDBHealthCheckTests
     public async Task CheckHealthAsync_WhenOptionsAreNull_ShouldReturnUnhealthy()
     {
         // Arrange
-        var optionsMonitor = Substitute.For<IOptionsMonitor<LiteDBOptions>>();
-        var serviceProvider = Substitute.For<IServiceProvider>();
+        var optionsMonitor = IOptionsMonitor<LiteDBOptions>.Mock();
+        var serviceProvider = IServiceProvider.Mock();
         var check = new LiteDBHealthCheck(serviceProvider, optionsMonitor);
         var context = new HealthCheckContext
         {

--- a/tests/NetEvolve.HealthChecks.Tests.Unit/MariaDb/MariaDbHealthCheckTests.cs
+++ b/tests/NetEvolve.HealthChecks.Tests.Unit/MariaDb/MariaDbHealthCheckTests.cs
@@ -7,7 +7,7 @@ using Microsoft.Extensions.Diagnostics.HealthChecks;
 using Microsoft.Extensions.Options;
 using NetEvolve.Extensions.TUnit;
 using NetEvolve.HealthChecks.MariaDb;
-using NSubstitute;
+using TUnit.Mocks;
 
 [TestGroup(nameof(MariaDb))]
 public sealed class MariaDbHealthCheckTests
@@ -18,7 +18,7 @@ public sealed class MariaDbHealthCheckTests
     public async Task CheckHealthAsync_WhenContextNull_ThrowArgumentNullException()
     {
         // Arrange
-        var optionsMonitor = Substitute.For<IOptionsMonitor<MariaDbOptions>>();
+        var optionsMonitor = IOptionsMonitor<MariaDbOptions>.Mock();
         var check = new MariaDbHealthCheck(optionsMonitor);
 
         // Act
@@ -32,7 +32,7 @@ public sealed class MariaDbHealthCheckTests
     public async Task CheckHealthAsync_WhenCancellationTokenIsCancelled_ShouldReturnUnhealthy()
     {
         // Arrange
-        var optionsMonitor = Substitute.For<IOptionsMonitor<MariaDbOptions>>();
+        var optionsMonitor = IOptionsMonitor<MariaDbOptions>.Mock();
         var check = new MariaDbHealthCheck(optionsMonitor);
         var context = new HealthCheckContext
         {
@@ -55,7 +55,7 @@ public sealed class MariaDbHealthCheckTests
     public async Task CheckHealthAsync_WhenOptionsAreNull_ShouldReturnUnhealthy()
     {
         // Arrange
-        var optionsMonitor = Substitute.For<IOptionsMonitor<MariaDbOptions>>();
+        var optionsMonitor = IOptionsMonitor<MariaDbOptions>.Mock();
         var check = new MariaDbHealthCheck(optionsMonitor);
         var context = new HealthCheckContext
         {

--- a/tests/NetEvolve.HealthChecks.Tests.Unit/Milvus/MilvusHealthCheckTests.cs
+++ b/tests/NetEvolve.HealthChecks.Tests.Unit/Milvus/MilvusHealthCheckTests.cs
@@ -7,7 +7,7 @@ using Microsoft.Extensions.Diagnostics.HealthChecks;
 using Microsoft.Extensions.Options;
 using NetEvolve.Extensions.TUnit;
 using NetEvolve.HealthChecks.Milvus;
-using NSubstitute;
+using TUnit.Mocks;
 
 [TestGroup(nameof(Milvus))]
 public sealed class MilvusHealthCheckTests
@@ -18,8 +18,8 @@ public sealed class MilvusHealthCheckTests
     public async Task CheckHealthAsync_WhenContextNull_ThrowArgumentNullException()
     {
         // Arrange
-        var optionsMonitor = Substitute.For<IOptionsMonitor<MilvusOptions>>();
-        var serviceProvider = Substitute.For<IServiceProvider>();
+        var optionsMonitor = IOptionsMonitor<MilvusOptions>.Mock();
+        var serviceProvider = IServiceProvider.Mock();
         var check = new MilvusHealthCheck(serviceProvider, optionsMonitor);
 
         // Act
@@ -33,8 +33,8 @@ public sealed class MilvusHealthCheckTests
     public async Task CheckHealthAsync_WhenCancellationTokenIsCancelled_ShouldReturnUnhealthy()
     {
         // Arrange
-        var optionsMonitor = Substitute.For<IOptionsMonitor<MilvusOptions>>();
-        var serviceProvider = Substitute.For<IServiceProvider>();
+        var optionsMonitor = IOptionsMonitor<MilvusOptions>.Mock();
+        var serviceProvider = IServiceProvider.Mock();
         var check = new MilvusHealthCheck(serviceProvider, optionsMonitor);
         var context = new HealthCheckContext
         {
@@ -57,8 +57,8 @@ public sealed class MilvusHealthCheckTests
     public async Task CheckHealthAsync_WhenOptionsAreNull_ShouldReturnUnhealthy()
     {
         // Arrange
-        var optionsMonitor = Substitute.For<IOptionsMonitor<MilvusOptions>>();
-        var serviceProvider = Substitute.For<IServiceProvider>();
+        var optionsMonitor = IOptionsMonitor<MilvusOptions>.Mock();
+        var serviceProvider = IServiceProvider.Mock();
         var check = new MilvusHealthCheck(serviceProvider, optionsMonitor);
         var context = new HealthCheckContext
         {

--- a/tests/NetEvolve.HealthChecks.Tests.Unit/Minio/MinioHealthCheckTests.cs
+++ b/tests/NetEvolve.HealthChecks.Tests.Unit/Minio/MinioHealthCheckTests.cs
@@ -8,7 +8,7 @@ using Microsoft.Extensions.Diagnostics.HealthChecks;
 using Microsoft.Extensions.Options;
 using NetEvolve.Extensions.TUnit;
 using NetEvolve.HealthChecks.Minio;
-using NSubstitute;
+using TUnit.Mocks;
 
 [TestGroup(nameof(Minio))]
 public class MinioHealthCheckTests
@@ -19,10 +19,8 @@ public class MinioHealthCheckTests
     public async Task DefaultCommandAsync_WhenBucketExists_ReturnsTrue()
     {
         // Arrange
-        var client = Substitute.For<IMinioClient>();
-        _ = client
-            .BucketExistsAsync(Arg.Any<global::Minio.DataModel.Args.BucketExistsArgs>(), Arg.Any<CancellationToken>())
-            .Returns(Task.FromResult(true));
+        var client = IMinioClient.Mock();
+        _ = client.BucketExistsAsync(Any(), Any()).Returns(true);
 
         // Act
         var result = await MinioHealthCheck.DefaultCommandAsync(client, "test-bucket", CancellationToken.None);
@@ -35,10 +33,8 @@ public class MinioHealthCheckTests
     public async Task DefaultCommandAsync_WhenBucketDoesNotExist_ReturnsFalse()
     {
         // Arrange
-        var client = Substitute.For<IMinioClient>();
-        _ = client
-            .BucketExistsAsync(Arg.Any<global::Minio.DataModel.Args.BucketExistsArgs>(), Arg.Any<CancellationToken>())
-            .Returns(Task.FromResult(false));
+        var client = IMinioClient.Mock();
+        _ = client.BucketExistsAsync(Any(), Any()).Returns(false);
 
         // Act
         var result = await MinioHealthCheck.DefaultCommandAsync(client, "non-existing-bucket", CancellationToken.None);
@@ -51,7 +47,7 @@ public class MinioHealthCheckTests
     public async Task CheckHealthAsync_WhenCommandReturnsFalse_ShouldReturnUnhealthyWithMessage()
     {
         // Arrange
-        var client = Substitute.For<IMinioClient>();
+        var client = IMinioClient.Mock();
         var options = new MinioOptions
         {
             KeyedService = null,
@@ -64,11 +60,11 @@ public class MinioHealthCheckTests
             },
         };
 
-        var optionsMonitor = Substitute.For<IOptionsMonitor<MinioOptions>>();
+        var optionsMonitor = IOptionsMonitor<MinioOptions>.Mock();
         _ = optionsMonitor.Get(TestName).Returns(options);
 
         var serviceCollection = new ServiceCollection();
-        _ = serviceCollection.AddSingleton(client);
+        _ = serviceCollection.AddSingleton<IMinioClient>(client);
         var serviceProvider = serviceCollection.BuildServiceProvider();
 
         var healthCheck = new MinioHealthCheck(serviceProvider, optionsMonitor);
@@ -94,7 +90,7 @@ public class MinioHealthCheckTests
     public async Task CheckHealthAsync_WhenCommandReturnsTrue_ShouldReturnHealthy()
     {
         // Arrange
-        var client = Substitute.For<IMinioClient>();
+        var client = IMinioClient.Mock();
         var options = new MinioOptions
         {
             KeyedService = null,
@@ -107,11 +103,11 @@ public class MinioHealthCheckTests
             },
         };
 
-        var optionsMonitor = Substitute.For<IOptionsMonitor<MinioOptions>>();
+        var optionsMonitor = IOptionsMonitor<MinioOptions>.Mock();
         _ = optionsMonitor.Get(TestName).Returns(options);
 
         var serviceCollection = new ServiceCollection();
-        _ = serviceCollection.AddSingleton(client);
+        _ = serviceCollection.AddSingleton<IMinioClient>(client);
         var serviceProvider = serviceCollection.BuildServiceProvider();
 
         var healthCheck = new MinioHealthCheck(serviceProvider, optionsMonitor);

--- a/tests/NetEvolve.HealthChecks.Tests.Unit/MongoDb/MongoDbHealthCheckTests.cs
+++ b/tests/NetEvolve.HealthChecks.Tests.Unit/MongoDb/MongoDbHealthCheckTests.cs
@@ -9,7 +9,7 @@ using Microsoft.Extensions.Options;
 using MongoDB.Driver;
 using NetEvolve.Extensions.TUnit;
 using NetEvolve.HealthChecks.MongoDb;
-using NSubstitute;
+using TUnit.Mocks;
 
 [TestGroup(nameof(MongoDb))]
 public sealed class MongoDbHealthCheckTests
@@ -20,8 +20,8 @@ public sealed class MongoDbHealthCheckTests
     public async Task CheckHealthAsync_WhenContextNull_ThrowArgumentNullException()
     {
         // Arrange
-        var serviceProvider = Substitute.For<IServiceProvider>();
-        var optionsMonitor = Substitute.For<IOptionsMonitor<MongoDbOptions>>();
+        var serviceProvider = IServiceProvider.Mock();
+        var optionsMonitor = IOptionsMonitor<MongoDbOptions>.Mock();
         var check = new MongoDbHealthCheck(serviceProvider, optionsMonitor);
 
         // Act
@@ -35,8 +35,8 @@ public sealed class MongoDbHealthCheckTests
     public async Task CheckHealthAsync_WhenCancellationTokenIsCancelled_ShouldReturnUnhealthy()
     {
         // Arrange
-        var serviceProvider = Substitute.For<IServiceProvider>();
-        var optionsMonitor = Substitute.For<IOptionsMonitor<MongoDbOptions>>();
+        var serviceProvider = IServiceProvider.Mock();
+        var optionsMonitor = IOptionsMonitor<MongoDbOptions>.Mock();
 
         var check = new MongoDbHealthCheck(serviceProvider, optionsMonitor);
         var context = new HealthCheckContext
@@ -60,8 +60,8 @@ public sealed class MongoDbHealthCheckTests
     public async Task CheckHealthAsync_WhenOptionsAreNull_ShouldReturnUnhealthy()
     {
         // Arrange
-        var serviceProvider = Substitute.For<IServiceProvider>();
-        var optionsMonitor = Substitute.For<IOptionsMonitor<MongoDbOptions>>();
+        var serviceProvider = IServiceProvider.Mock();
+        var optionsMonitor = IOptionsMonitor<MongoDbOptions>.Mock();
 
         var check = new MongoDbHealthCheck(serviceProvider, optionsMonitor);
         var context = new HealthCheckContext
@@ -95,7 +95,7 @@ public sealed class MongoDbHealthCheckTests
             },
         };
 
-        var optionsMonitor = Substitute.For<IOptionsMonitor<MongoDbOptions>>();
+        var optionsMonitor = IOptionsMonitor<MongoDbOptions>.Mock();
         _ = optionsMonitor.Get(TestName).Returns(options);
 
         // Setup client mock that returns success
@@ -137,7 +137,7 @@ public sealed class MongoDbHealthCheckTests
             },
         };
 
-        var optionsMonitor = Substitute.For<IOptionsMonitor<MongoDbOptions>>();
+        var optionsMonitor = IOptionsMonitor<MongoDbOptions>.Mock();
         _ = optionsMonitor.Get(TestName).Returns(options);
 
         // Setup connection mock that returns success
@@ -179,7 +179,7 @@ public sealed class MongoDbHealthCheckTests
             },
         };
 
-        var optionsMonitor = Substitute.For<IOptionsMonitor<MongoDbOptions>>();
+        var optionsMonitor = IOptionsMonitor<MongoDbOptions>.Mock();
         _ = optionsMonitor.Get(TestName).Returns(options);
 
         // Setup connection mock that throws an exception

--- a/tests/NetEvolve.HealthChecks.Tests.Unit/Mosquitto/MosquittoHealthCheckTests.cs
+++ b/tests/NetEvolve.HealthChecks.Tests.Unit/Mosquitto/MosquittoHealthCheckTests.cs
@@ -9,7 +9,7 @@ using Microsoft.Extensions.Options;
 using MQTTnet;
 using NetEvolve.Extensions.TUnit;
 using NetEvolve.HealthChecks.Mosquitto;
-using NSubstitute;
+using TUnit.Mocks;
 
 [TestGroup(nameof(Mosquitto))]
 public sealed class MosquittoHealthCheckTests
@@ -22,15 +22,15 @@ public sealed class MosquittoHealthCheckTests
         // Arrange
         var options = new MosquittoOptions { KeyedService = "test-key", Timeout = 10000 };
 
-        var optionsMonitor = Substitute.For<IOptionsMonitor<MosquittoOptions>>();
+        var optionsMonitor = IOptionsMonitor<MosquittoOptions>.Mock();
         _ = optionsMonitor.Get(TestName).Returns(options);
 
         // Setup client mock that returns success
-        var mockClient = Substitute.For<IMqttClient>();
+        var mockClient = IMqttClient.Mock();
         _ = mockClient.IsConnected.Returns(true);
 
         var serviceCollection = new ServiceCollection();
-        _ = serviceCollection.AddKeyedSingleton("test-key", mockClient);
+        _ = serviceCollection.AddKeyedSingleton<IMqttClient>("test-key", mockClient);
         var serviceProvider = serviceCollection.BuildServiceProvider();
 
         var healthCheck = new MosquittoHealthCheck(serviceProvider, optionsMonitor);
@@ -56,15 +56,15 @@ public sealed class MosquittoHealthCheckTests
         // Arrange
         var options = new MosquittoOptions { KeyedService = null, Timeout = 1000 };
 
-        var optionsMonitor = Substitute.For<IOptionsMonitor<MosquittoOptions>>();
+        var optionsMonitor = IOptionsMonitor<MosquittoOptions>.Mock();
         _ = optionsMonitor.Get(TestName).Returns(options);
 
         // Setup client mock that returns success
-        var mockClient = Substitute.For<IMqttClient>();
+        var mockClient = IMqttClient.Mock();
         _ = mockClient.IsConnected.Returns(true);
 
         var serviceCollection = new ServiceCollection();
-        _ = serviceCollection.AddSingleton(mockClient);
+        _ = serviceCollection.AddSingleton<IMqttClient>(mockClient);
         var serviceProvider = serviceCollection.BuildServiceProvider();
 
         var healthCheck = new MosquittoHealthCheck(serviceProvider, optionsMonitor);
@@ -90,15 +90,15 @@ public sealed class MosquittoHealthCheckTests
         // Arrange
         var options = new MosquittoOptions { KeyedService = null, Timeout = 1000 };
 
-        var optionsMonitor = Substitute.For<IOptionsMonitor<MosquittoOptions>>();
+        var optionsMonitor = IOptionsMonitor<MosquittoOptions>.Mock();
         _ = optionsMonitor.Get(TestName).Returns(options);
 
         // Setup client mock that returns not connected
-        var mockClient = Substitute.For<IMqttClient>();
+        var mockClient = IMqttClient.Mock();
         _ = mockClient.IsConnected.Returns(false);
 
         var serviceCollection = new ServiceCollection();
-        _ = serviceCollection.AddSingleton(mockClient);
+        _ = serviceCollection.AddSingleton<IMqttClient>(mockClient);
         var serviceProvider = serviceCollection.BuildServiceProvider();
 
         var healthCheck = new MosquittoHealthCheck(serviceProvider, optionsMonitor);

--- a/tests/NetEvolve.HealthChecks.Tests.Unit/MySql.Devart/MySqlDevartHealthCheckTests.cs
+++ b/tests/NetEvolve.HealthChecks.Tests.Unit/MySql.Devart/MySqlDevartHealthCheckTests.cs
@@ -7,7 +7,7 @@ using Microsoft.Extensions.Diagnostics.HealthChecks;
 using Microsoft.Extensions.Options;
 using NetEvolve.Extensions.TUnit;
 using NetEvolve.HealthChecks.MySql.Devart;
-using NSubstitute;
+using TUnit.Mocks;
 
 [TestGroup($"{nameof(MySql)}.{nameof(Devart)}")]
 public sealed class MySqlDevartHealthCheckTests
@@ -18,7 +18,7 @@ public sealed class MySqlDevartHealthCheckTests
     public async Task CheckHealthAsync_WhenContextNull_ThrowArgumentNullException()
     {
         // Arrange
-        var optionsMonitor = Substitute.For<IOptionsMonitor<MySqlDevartOptions>>();
+        var optionsMonitor = IOptionsMonitor<MySqlDevartOptions>.Mock();
         var check = new MySqlDevartHealthCheck(optionsMonitor);
 
         // Act
@@ -32,7 +32,7 @@ public sealed class MySqlDevartHealthCheckTests
     public async Task CheckHealthAsync_WhenCancellationTokenIsCancelled_ShouldReturnUnhealthy()
     {
         // Arrange
-        var optionsMonitor = Substitute.For<IOptionsMonitor<MySqlDevartOptions>>();
+        var optionsMonitor = IOptionsMonitor<MySqlDevartOptions>.Mock();
         var check = new MySqlDevartHealthCheck(optionsMonitor);
         var context = new HealthCheckContext
         {
@@ -55,7 +55,7 @@ public sealed class MySqlDevartHealthCheckTests
     public async Task CheckHealthAsync_WhenOptionsAreNull_ShouldReturnUnhealthy()
     {
         // Arrange
-        var optionsMonitor = Substitute.For<IOptionsMonitor<MySqlDevartOptions>>();
+        var optionsMonitor = IOptionsMonitor<MySqlDevartOptions>.Mock();
         var check = new MySqlDevartHealthCheck(optionsMonitor);
         var context = new HealthCheckContext
         {

--- a/tests/NetEvolve.HealthChecks.Tests.Unit/MySql/MySqlHealthCheckTests.cs
+++ b/tests/NetEvolve.HealthChecks.Tests.Unit/MySql/MySqlHealthCheckTests.cs
@@ -7,7 +7,7 @@ using Microsoft.Extensions.Diagnostics.HealthChecks;
 using Microsoft.Extensions.Options;
 using NetEvolve.Extensions.TUnit;
 using NetEvolve.HealthChecks.MySql;
-using NSubstitute;
+using TUnit.Mocks;
 
 [TestGroup(nameof(MySql))]
 public sealed class MySqlHealthCheckTests
@@ -18,7 +18,7 @@ public sealed class MySqlHealthCheckTests
     public async Task CheckHealthAsync_WhenContextNull_ThrowArgumentNullException()
     {
         // Arrange
-        var optionsMonitor = Substitute.For<IOptionsMonitor<MySqlOptions>>();
+        var optionsMonitor = IOptionsMonitor<MySqlOptions>.Mock();
         var check = new MySqlHealthCheck(optionsMonitor);
 
         // Act
@@ -32,7 +32,7 @@ public sealed class MySqlHealthCheckTests
     public async Task CheckHealthAsync_WhenCancellationTokenIsCancelled_ShouldReturnUnhealthy()
     {
         // Arrange
-        var optionsMonitor = Substitute.For<IOptionsMonitor<MySqlOptions>>();
+        var optionsMonitor = IOptionsMonitor<MySqlOptions>.Mock();
         var check = new MySqlHealthCheck(optionsMonitor);
         var context = new HealthCheckContext
         {
@@ -55,7 +55,7 @@ public sealed class MySqlHealthCheckTests
     public async Task CheckHealthAsync_WhenOptionsAreNull_ShouldReturnUnhealthy()
     {
         // Arrange
-        var optionsMonitor = Substitute.For<IOptionsMonitor<MySqlOptions>>();
+        var optionsMonitor = IOptionsMonitor<MySqlOptions>.Mock();
         var check = new MySqlHealthCheck(optionsMonitor);
         var context = new HealthCheckContext
         {

--- a/tests/NetEvolve.HealthChecks.Tests.Unit/MySqlConnector/MySqlHealthCheckTests.cs
+++ b/tests/NetEvolve.HealthChecks.Tests.Unit/MySqlConnector/MySqlHealthCheckTests.cs
@@ -7,7 +7,7 @@ using Microsoft.Extensions.Diagnostics.HealthChecks;
 using Microsoft.Extensions.Options;
 using NetEvolve.Extensions.TUnit;
 using NetEvolve.HealthChecks.MySql.Connector;
-using NSubstitute;
+using TUnit.Mocks;
 
 [TestGroup(nameof(MySqlConnector))]
 public sealed class MySqlHealthCheckTests
@@ -18,7 +18,7 @@ public sealed class MySqlHealthCheckTests
     public async Task CheckHealthAsync_WhenContextNull_ThrowArgumentNullException()
     {
         // Arrange
-        var optionsMonitor = Substitute.For<IOptionsMonitor<MySqlOptions>>();
+        var optionsMonitor = IOptionsMonitor<MySqlOptions>.Mock();
         var check = new MySqlHealthCheck(optionsMonitor);
 
         // Act
@@ -32,7 +32,7 @@ public sealed class MySqlHealthCheckTests
     public async Task CheckHealthAsync_WhenCancellationTokenIsCancelled_ShouldReturnUnhealthy()
     {
         // Arrange
-        var optionsMonitor = Substitute.For<IOptionsMonitor<MySqlOptions>>();
+        var optionsMonitor = IOptionsMonitor<MySqlOptions>.Mock();
         var check = new MySqlHealthCheck(optionsMonitor);
         var context = new HealthCheckContext
         {
@@ -55,7 +55,7 @@ public sealed class MySqlHealthCheckTests
     public async Task CheckHealthAsync_WhenOptionsAreNull_ShouldReturnUnhealthy()
     {
         // Arrange
-        var optionsMonitor = Substitute.For<IOptionsMonitor<MySqlOptions>>();
+        var optionsMonitor = IOptionsMonitor<MySqlOptions>.Mock();
         var check = new MySqlHealthCheck(optionsMonitor);
         var context = new HealthCheckContext
         {

--- a/tests/NetEvolve.HealthChecks.Tests.Unit/NATS/NATSHealthCheckTests.cs
+++ b/tests/NetEvolve.HealthChecks.Tests.Unit/NATS/NATSHealthCheckTests.cs
@@ -9,7 +9,7 @@ using Microsoft.Extensions.Diagnostics.HealthChecks;
 using Microsoft.Extensions.Options;
 using NetEvolve.Extensions.TUnit;
 using NetEvolve.HealthChecks.NATS;
-using NSubstitute;
+using TUnit.Mocks;
 
 [TestGroup(nameof(NATS))]
 public sealed class NATSHealthCheckTests
@@ -22,15 +22,15 @@ public sealed class NATSHealthCheckTests
         // Arrange
         var options = new NatsOptions { KeyedService = "test-key", Timeout = 10000 };
 
-        var optionsMonitor = Substitute.For<IOptionsMonitor<NatsOptions>>();
+        var optionsMonitor = IOptionsMonitor<NatsOptions>.Mock();
         _ = optionsMonitor.Get(TestName).Returns(options);
 
         // Setup connection mock that returns success
-        var mockConnection = Substitute.For<IConnection>();
+        var mockConnection = IConnection.Mock();
         _ = mockConnection.State.Returns(ConnState.CONNECTED);
 
         var serviceCollection = new ServiceCollection();
-        _ = serviceCollection.AddKeyedSingleton("test-key", mockConnection);
+        _ = serviceCollection.AddKeyedSingleton<IConnection>("test-key", mockConnection);
         var serviceProvider = serviceCollection.BuildServiceProvider();
 
         var healthCheck = new NatsHealthCheck(serviceProvider, optionsMonitor);
@@ -56,15 +56,15 @@ public sealed class NATSHealthCheckTests
         // Arrange
         var options = new NatsOptions { KeyedService = null, Timeout = 1000 };
 
-        var optionsMonitor = Substitute.For<IOptionsMonitor<NatsOptions>>();
+        var optionsMonitor = IOptionsMonitor<NatsOptions>.Mock();
         _ = optionsMonitor.Get(TestName).Returns(options);
 
         // Setup connection mock that returns success
-        var mockConnection = Substitute.For<IConnection>();
+        var mockConnection = IConnection.Mock();
         _ = mockConnection.State.Returns(ConnState.CONNECTED);
 
         var serviceCollection = new ServiceCollection();
-        _ = serviceCollection.AddSingleton(mockConnection);
+        _ = serviceCollection.AddSingleton<IConnection>(mockConnection);
         var serviceProvider = serviceCollection.BuildServiceProvider();
 
         var healthCheck = new NatsHealthCheck(serviceProvider, optionsMonitor);
@@ -90,15 +90,15 @@ public sealed class NATSHealthCheckTests
         // Arrange
         var options = new NatsOptions { KeyedService = null, Timeout = 1000 };
 
-        var optionsMonitor = Substitute.For<IOptionsMonitor<NatsOptions>>();
+        var optionsMonitor = IOptionsMonitor<NatsOptions>.Mock();
         _ = optionsMonitor.Get(TestName).Returns(options);
 
         // Setup connection mock that returns closed state
-        var mockConnection = Substitute.For<IConnection>();
+        var mockConnection = IConnection.Mock();
         _ = mockConnection.State.Returns(ConnState.CLOSED);
 
         var serviceCollection = new ServiceCollection();
-        _ = serviceCollection.AddSingleton(mockConnection);
+        _ = serviceCollection.AddSingleton<IConnection>(mockConnection);
         var serviceProvider = serviceCollection.BuildServiceProvider();
 
         var healthCheck = new NatsHealthCheck(serviceProvider, optionsMonitor);
@@ -130,21 +130,21 @@ public sealed class NATSHealthCheckTests
             Timeout = 0, // Very short timeout to force a timeout
         };
 
-        var optionsMonitor = Substitute.For<IOptionsMonitor<NatsOptions>>();
+        var optionsMonitor = IOptionsMonitor<NatsOptions>.Mock();
         _ = optionsMonitor.Get(TestName).Returns(options);
 
         // Setup connection mock that delays long enough to cause timeout
-        var mockConnection = Substitute.For<IConnection>();
+        var mockConnection = IConnection.Mock();
 
         // Configure the mock so that accessing State takes longer than the timeout
-        _ = mockConnection.State.Returns(_ =>
+        _ = mockConnection.State.Returns(() =>
         {
             Thread.Sleep(200); // Delay to force timeout
             return ConnState.CONNECTED;
         });
 
         var serviceCollection = new ServiceCollection();
-        _ = serviceCollection.AddSingleton(mockConnection);
+        _ = serviceCollection.AddSingleton<IConnection>(mockConnection);
         var serviceProvider = serviceCollection.BuildServiceProvider();
 
         var healthCheck = new NatsHealthCheck(serviceProvider, optionsMonitor);

--- a/tests/NetEvolve.HealthChecks.Tests.Unit/Neo4j/Neo4jHealthCheckTests.cs
+++ b/tests/NetEvolve.HealthChecks.Tests.Unit/Neo4j/Neo4jHealthCheckTests.cs
@@ -9,7 +9,7 @@ using Microsoft.Extensions.Diagnostics.HealthChecks;
 using Microsoft.Extensions.Options;
 using NetEvolve.Extensions.TUnit;
 using NetEvolve.HealthChecks.Neo4j;
-using NSubstitute;
+using TUnit.Mocks;
 
 [TestGroup(nameof(Neo4j))]
 public sealed class Neo4jHealthCheckTests
@@ -20,8 +20,8 @@ public sealed class Neo4jHealthCheckTests
     public async Task CheckHealthAsync_WhenContextNull_ThrowArgumentNullException()
     {
         // Arrange
-        var serviceProvider = Substitute.For<IServiceProvider>();
-        var optionsMonitor = Substitute.For<IOptionsMonitor<Neo4jOptions>>();
+        var serviceProvider = IServiceProvider.Mock();
+        var optionsMonitor = IOptionsMonitor<Neo4jOptions>.Mock();
         var check = new Neo4jHealthCheck(serviceProvider, optionsMonitor);
 
         // Act
@@ -35,8 +35,8 @@ public sealed class Neo4jHealthCheckTests
     public async Task CheckHealthAsync_WhenCancellationTokenIsCancelled_ShouldReturnUnhealthy()
     {
         // Arrange
-        var serviceProvider = Substitute.For<IServiceProvider>();
-        var optionsMonitor = Substitute.For<IOptionsMonitor<Neo4jOptions>>();
+        var serviceProvider = IServiceProvider.Mock();
+        var optionsMonitor = IOptionsMonitor<Neo4jOptions>.Mock();
 
         var check = new Neo4jHealthCheck(serviceProvider, optionsMonitor);
         var context = new HealthCheckContext
@@ -60,8 +60,8 @@ public sealed class Neo4jHealthCheckTests
     public async Task CheckHealthAsync_WhenOptionsAreNull_ShouldReturnUnhealthy()
     {
         // Arrange
-        var serviceProvider = Substitute.For<IServiceProvider>();
-        var optionsMonitor = Substitute.For<IOptionsMonitor<Neo4jOptions>>();
+        var serviceProvider = IServiceProvider.Mock();
+        var optionsMonitor = IOptionsMonitor<Neo4jOptions>.Mock();
 
         var check = new Neo4jHealthCheck(serviceProvider, optionsMonitor);
         var context = new HealthCheckContext
@@ -95,13 +95,13 @@ public sealed class Neo4jHealthCheckTests
             },
         };
 
-        var optionsMonitor = Substitute.For<IOptionsMonitor<Neo4jOptions>>();
+        var optionsMonitor = IOptionsMonitor<Neo4jOptions>.Mock();
         _ = optionsMonitor.Get(TestName).Returns(options);
 
-        var driver = Substitute.For<IDriver>();
+        var driver = IDriver.Mock();
 
         var serviceCollection = new ServiceCollection();
-        _ = serviceCollection.AddKeyedSingleton("test-key", driver);
+        _ = serviceCollection.AddKeyedSingleton<IDriver>("test-key", driver);
         var serviceProvider = serviceCollection.BuildServiceProvider();
 
         var healthCheck = new Neo4jHealthCheck(serviceProvider, optionsMonitor);
@@ -136,13 +136,13 @@ public sealed class Neo4jHealthCheckTests
             },
         };
 
-        var optionsMonitor = Substitute.For<IOptionsMonitor<Neo4jOptions>>();
+        var optionsMonitor = IOptionsMonitor<Neo4jOptions>.Mock();
         _ = optionsMonitor.Get(TestName).Returns(options);
 
-        var driver = Substitute.For<IDriver>();
+        var driver = IDriver.Mock();
 
         var serviceCollection = new ServiceCollection();
-        _ = serviceCollection.AddSingleton(driver);
+        _ = serviceCollection.AddSingleton<IDriver>(driver);
         var serviceProvider = serviceCollection.BuildServiceProvider();
 
         var healthCheck = new Neo4jHealthCheck(serviceProvider, optionsMonitor);
@@ -177,13 +177,13 @@ public sealed class Neo4jHealthCheckTests
             },
         };
 
-        var optionsMonitor = Substitute.For<IOptionsMonitor<Neo4jOptions>>();
+        var optionsMonitor = IOptionsMonitor<Neo4jOptions>.Mock();
         _ = optionsMonitor.Get(TestName).Returns(options);
 
-        var driver = Substitute.For<IDriver>();
+        var driver = IDriver.Mock();
 
         var serviceCollection = new ServiceCollection();
-        _ = serviceCollection.AddSingleton(driver);
+        _ = serviceCollection.AddSingleton<IDriver>(driver);
         var serviceProvider = serviceCollection.BuildServiceProvider();
 
         var healthCheck = new Neo4jHealthCheck(serviceProvider, optionsMonitor);

--- a/tests/NetEvolve.HealthChecks.Tests.Unit/NetEvolve.HealthChecks.Tests.Unit.csproj
+++ b/tests/NetEvolve.HealthChecks.Tests.Unit/NetEvolve.HealthChecks.Tests.Unit.csproj
@@ -16,12 +16,39 @@
     <PackageReference Include="Minio" />
     <PackageReference Include="NATS.Client" />
     <PackageReference Include="NetEvolve.Extensions.TUnit" />
+    <!--
+      NSubstitute is retained for a handful of files that TUnit.Mocks 1.61.38's alpha source
+      generator can't (yet) handle. Remove once the linked upstream issues are fixed and these
+      files are migrated too:
+        - RavenDb: mocking IDocumentStore fails (nested ISessionBlittableJsonConverter member
+          with asymmetric property accessors, CS0535/CS0548/CS0551).
+          https://github.com/thomhurst/TUnit/issues/6491
+        - Elasticsearch: mocking ElasticsearchClientSettings fails (generator emits an invalid
+          nullable-type pattern, CS8116).
+          https://github.com/thomhurst/TUnit/issues/6492
+        - Azure.ServiceBus (Queue/Subscription/Topic Administration): mocking
+          ServiceBusAdministrationClient pulls in QueueRuntimeProperties/
+          SubscriptionRuntimeProperties/TopicRuntimeProperties, none of which have an accessible
+          parameterless constructor (CS1729).
+          https://github.com/thomhurst/TUnit/issues/6493
+        - Cassandra: mocking Cassandra.ICluster collides with Couchbase.ICluster (also mocked in
+          this project, see Couchbase/CouchbaseHealthCheckTests.cs) - the generator names the
+          wrapper type "IClusterMock" without namespace-qualifying it, so having both interfaces
+          mocked in the same compilation silently breaks one of them (CS1061: generated wrapper
+          is missing the real interface's members entirely).
+          https://github.com/thomhurst/TUnit/issues/6494
+        - RabbitMQ: one test only (CheckHealthAsync_WhenTimeout_ReturnsDegraded) - .Returns() only
+          accepts a synchronous Func<T>, so a mocked call can't hand back a task that stays pending
+          and completes later, which this test's genuine async timeout-race depends on.
+          https://github.com/thomhurst/TUnit/issues/6495
+    -->
     <PackageReference Include="NSubstitute" />
     <PackageReference Include="NSubstitute.Analyzers.CSharp">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="TUnit" />
+    <PackageReference Include="TUnit.Mocks" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\NetEvolve.HealthChecks.Apache.ActiveMq\NetEvolve.HealthChecks.Apache.ActiveMq.csproj" />

--- a/tests/NetEvolve.HealthChecks.Tests.Unit/Npgsql.Devart/NpgsqlDevartHealthCheckTests.cs
+++ b/tests/NetEvolve.HealthChecks.Tests.Unit/Npgsql.Devart/NpgsqlDevartHealthCheckTests.cs
@@ -7,7 +7,7 @@ using Microsoft.Extensions.Diagnostics.HealthChecks;
 using Microsoft.Extensions.Options;
 using NetEvolve.Extensions.TUnit;
 using NetEvolve.HealthChecks.Npgsql.Devart;
-using NSubstitute;
+using TUnit.Mocks;
 
 [TestGroup($"{nameof(Npgsql)}.{nameof(Devart)}")]
 public sealed class NpgsqlDevartHealthCheckTests
@@ -18,7 +18,7 @@ public sealed class NpgsqlDevartHealthCheckTests
     public async Task CheckHealthAsync_WhenContextNull_ThrowArgumentNullException()
     {
         // Arrange
-        var optionsMonitor = Substitute.For<IOptionsMonitor<NpgsqlDevartOptions>>();
+        var optionsMonitor = IOptionsMonitor<NpgsqlDevartOptions>.Mock();
         var check = new NpgsqlDevartHealthCheck(optionsMonitor);
 
         // Act
@@ -32,7 +32,7 @@ public sealed class NpgsqlDevartHealthCheckTests
     public async Task CheckHealthAsync_WhenCancellationTokenIsCancelled_ShouldReturnUnhealthy()
     {
         // Arrange
-        var optionsMonitor = Substitute.For<IOptionsMonitor<NpgsqlDevartOptions>>();
+        var optionsMonitor = IOptionsMonitor<NpgsqlDevartOptions>.Mock();
         var check = new NpgsqlDevartHealthCheck(optionsMonitor);
         var context = new HealthCheckContext
         {
@@ -55,7 +55,7 @@ public sealed class NpgsqlDevartHealthCheckTests
     public async Task CheckHealthAsync_WhenOptionsAreNull_ShouldReturnUnhealthy()
     {
         // Arrange
-        var optionsMonitor = Substitute.For<IOptionsMonitor<NpgsqlDevartOptions>>();
+        var optionsMonitor = IOptionsMonitor<NpgsqlDevartOptions>.Mock();
         var check = new NpgsqlDevartHealthCheck(optionsMonitor);
         var context = new HealthCheckContext
         {

--- a/tests/NetEvolve.HealthChecks.Tests.Unit/Npgsql/NpgsqlHealthCheckTests.cs
+++ b/tests/NetEvolve.HealthChecks.Tests.Unit/Npgsql/NpgsqlHealthCheckTests.cs
@@ -7,7 +7,7 @@ using Microsoft.Extensions.Diagnostics.HealthChecks;
 using Microsoft.Extensions.Options;
 using NetEvolve.Extensions.TUnit;
 using NetEvolve.HealthChecks.Npgsql;
-using NSubstitute;
+using TUnit.Mocks;
 
 [TestGroup(nameof(Npgsql))]
 public sealed class NpgsqlHealthCheckTests
@@ -18,7 +18,7 @@ public sealed class NpgsqlHealthCheckTests
     public async Task CheckHealthAsync_WhenContextNull_ThrowArgumentNullException()
     {
         // Arrange
-        var optionsMonitor = Substitute.For<IOptionsMonitor<NpgsqlOptions>>();
+        var optionsMonitor = IOptionsMonitor<NpgsqlOptions>.Mock();
         var check = new NpgsqlHealthCheck(optionsMonitor);
 
         // Act
@@ -32,7 +32,7 @@ public sealed class NpgsqlHealthCheckTests
     public async Task CheckHealthAsync_WhenCancellationTokenIsCancelled_ShouldReturnUnhealthy()
     {
         // Arrange
-        var optionsMonitor = Substitute.For<IOptionsMonitor<NpgsqlOptions>>();
+        var optionsMonitor = IOptionsMonitor<NpgsqlOptions>.Mock();
         var check = new NpgsqlHealthCheck(optionsMonitor);
         var context = new HealthCheckContext
         {
@@ -55,7 +55,7 @@ public sealed class NpgsqlHealthCheckTests
     public async Task CheckHealthAsync_WhenOptionsAreNull_ShouldReturnUnhealthy()
     {
         // Arrange
-        var optionsMonitor = Substitute.For<IOptionsMonitor<NpgsqlOptions>>();
+        var optionsMonitor = IOptionsMonitor<NpgsqlOptions>.Mock();
         var check = new NpgsqlHealthCheck(optionsMonitor);
         var context = new HealthCheckContext
         {

--- a/tests/NetEvolve.HealthChecks.Tests.Unit/Odbc/OdbcHealthCheckTests.cs
+++ b/tests/NetEvolve.HealthChecks.Tests.Unit/Odbc/OdbcHealthCheckTests.cs
@@ -7,7 +7,7 @@ using Microsoft.Extensions.Diagnostics.HealthChecks;
 using Microsoft.Extensions.Options;
 using NetEvolve.Extensions.TUnit;
 using NetEvolve.HealthChecks.Odbc;
-using NSubstitute;
+using TUnit.Mocks;
 
 [TestGroup(nameof(Odbc))]
 public sealed class OdbcHealthCheckTests
@@ -18,7 +18,7 @@ public sealed class OdbcHealthCheckTests
     public async Task CheckHealthAsync_WhenContextNull_ThrowArgumentNullException()
     {
         // Arrange
-        var optionsMonitor = Substitute.For<IOptionsMonitor<OdbcOptions>>();
+        var optionsMonitor = IOptionsMonitor<OdbcOptions>.Mock();
         var check = new OdbcHealthCheck(optionsMonitor);
 
         // Act
@@ -32,7 +32,7 @@ public sealed class OdbcHealthCheckTests
     public async Task CheckHealthAsync_WhenCancellationTokenIsCancelled_ShouldReturnUnhealthy()
     {
         // Arrange
-        var optionsMonitor = Substitute.For<IOptionsMonitor<OdbcOptions>>();
+        var optionsMonitor = IOptionsMonitor<OdbcOptions>.Mock();
         var check = new OdbcHealthCheck(optionsMonitor);
         var context = new HealthCheckContext
         {
@@ -55,7 +55,7 @@ public sealed class OdbcHealthCheckTests
     public async Task CheckHealthAsync_WhenOptionsAreNull_ShouldReturnUnhealthy()
     {
         // Arrange
-        var optionsMonitor = Substitute.For<IOptionsMonitor<OdbcOptions>>();
+        var optionsMonitor = IOptionsMonitor<OdbcOptions>.Mock();
         var check = new OdbcHealthCheck(optionsMonitor);
         var context = new HealthCheckContext
         {

--- a/tests/NetEvolve.HealthChecks.Tests.Unit/Ollama/OllamaHealthCheckTests.cs
+++ b/tests/NetEvolve.HealthChecks.Tests.Unit/Ollama/OllamaHealthCheckTests.cs
@@ -7,7 +7,7 @@ using Microsoft.Extensions.Diagnostics.HealthChecks;
 using Microsoft.Extensions.Options;
 using NetEvolve.Extensions.TUnit;
 using NetEvolve.HealthChecks.Ollama;
-using NSubstitute;
+using TUnit.Mocks;
 
 [TestGroup(nameof(Ollama))]
 public sealed class OllamaHealthCheckTests
@@ -18,8 +18,8 @@ public sealed class OllamaHealthCheckTests
     public async Task CheckHealthAsync_WhenContextNull_ThrowArgumentNullException()
     {
         // Arrange
-        var serviceProvider = Substitute.For<IServiceProvider>();
-        var optionsMonitor = Substitute.For<IOptionsMonitor<OllamaOptions>>();
+        var serviceProvider = IServiceProvider.Mock();
+        var optionsMonitor = IOptionsMonitor<OllamaOptions>.Mock();
         using var check = new OllamaHealthCheck(serviceProvider, optionsMonitor);
 
         // Act
@@ -33,8 +33,8 @@ public sealed class OllamaHealthCheckTests
     public async Task CheckHealthAsync_WhenCancellationTokenIsCancelled_ShouldReturnUnhealthy()
     {
         // Arrange
-        var serviceProvider = Substitute.For<IServiceProvider>();
-        var optionsMonitor = Substitute.For<IOptionsMonitor<OllamaOptions>>();
+        var serviceProvider = IServiceProvider.Mock();
+        var optionsMonitor = IOptionsMonitor<OllamaOptions>.Mock();
         using var check = new OllamaHealthCheck(serviceProvider, optionsMonitor);
         var context = new HealthCheckContext
         {
@@ -57,8 +57,8 @@ public sealed class OllamaHealthCheckTests
     public async Task CheckHealthAsync_WhenOptionsAreNull_ShouldReturnUnhealthy()
     {
         // Arrange
-        var serviceProvider = Substitute.For<IServiceProvider>();
-        var optionsMonitor = Substitute.For<IOptionsMonitor<OllamaOptions>>();
+        var serviceProvider = IServiceProvider.Mock();
+        var optionsMonitor = IOptionsMonitor<OllamaOptions>.Mock();
         using var check = new OllamaHealthCheck(serviceProvider, optionsMonitor);
         var context = new HealthCheckContext
         {

--- a/tests/NetEvolve.HealthChecks.Tests.Unit/OpenSearch/OpenSearchHealthCheckTests.cs
+++ b/tests/NetEvolve.HealthChecks.Tests.Unit/OpenSearch/OpenSearchHealthCheckTests.cs
@@ -9,7 +9,7 @@ using Microsoft.Extensions.Diagnostics.HealthChecks;
 using Microsoft.Extensions.Options;
 using NetEvolve.Extensions.TUnit;
 using NetEvolve.HealthChecks.OpenSearch;
-using NSubstitute;
+using TUnit.Mocks;
 
 [TestGroup(nameof(OpenSearch))]
 public sealed class OpenSearchHealthCheckTests
@@ -20,8 +20,8 @@ public sealed class OpenSearchHealthCheckTests
     public async Task CheckHealthAsync_WhenContextNull_ThrowArgumentNullException()
     {
         // Arrange
-        var serviceProvider = Substitute.For<IServiceProvider>();
-        var optionsMonitor = Substitute.For<IOptionsMonitor<OpenSearchOptions>>();
+        var serviceProvider = IServiceProvider.Mock();
+        var optionsMonitor = IOptionsMonitor<OpenSearchOptions>.Mock();
         var check = new OpenSearchHealthCheck(serviceProvider, optionsMonitor);
 
         // Act
@@ -35,8 +35,8 @@ public sealed class OpenSearchHealthCheckTests
     public async Task CheckHealthAsync_WhenCancellationTokenIsCancelled_ShouldReturnUnhealthy()
     {
         // Arrange
-        var serviceProvider = Substitute.For<IServiceProvider>();
-        var optionsMonitor = Substitute.For<IOptionsMonitor<OpenSearchOptions>>();
+        var serviceProvider = IServiceProvider.Mock();
+        var optionsMonitor = IOptionsMonitor<OpenSearchOptions>.Mock();
 
         var check = new OpenSearchHealthCheck(serviceProvider, optionsMonitor);
         var context = new HealthCheckContext
@@ -60,8 +60,8 @@ public sealed class OpenSearchHealthCheckTests
     public async Task CheckHealthAsync_WhenOptionsAreNull_ShouldReturnUnhealthy()
     {
         // Arrange
-        var serviceProvider = Substitute.For<IServiceProvider>();
-        var optionsMonitor = Substitute.For<IOptionsMonitor<OpenSearchOptions>>();
+        var serviceProvider = IServiceProvider.Mock();
+        var optionsMonitor = IOptionsMonitor<OpenSearchOptions>.Mock();
 
         var check = new OpenSearchHealthCheck(serviceProvider, optionsMonitor);
         var context = new HealthCheckContext
@@ -97,7 +97,7 @@ public sealed class OpenSearchHealthCheckTests
             },
         };
 
-        var optionsMonitor = Substitute.For<IOptionsMonitor<OpenSearchOptions>>();
+        var optionsMonitor = IOptionsMonitor<OpenSearchOptions>.Mock();
         _ = optionsMonitor.Get(TestName).Returns(options);
 
         // Setup client mock that returns success
@@ -142,7 +142,7 @@ public sealed class OpenSearchHealthCheckTests
             },
         };
 
-        var optionsMonitor = Substitute.For<IOptionsMonitor<OpenSearchOptions>>();
+        var optionsMonitor = IOptionsMonitor<OpenSearchOptions>.Mock();
         _ = optionsMonitor.Get(TestName).Returns(options);
 
         // Setup connection mock that returns success
@@ -187,7 +187,7 @@ public sealed class OpenSearchHealthCheckTests
             },
         };
 
-        var optionsMonitor = Substitute.For<IOptionsMonitor<OpenSearchOptions>>();
+        var optionsMonitor = IOptionsMonitor<OpenSearchOptions>.Mock();
         _ = optionsMonitor.Get(TestName).Returns(options);
 
         // Setup connection mock that throws an exception

--- a/tests/NetEvolve.HealthChecks.Tests.Unit/Oracle.Devart/OracleDevartHealthCheckTests.cs
+++ b/tests/NetEvolve.HealthChecks.Tests.Unit/Oracle.Devart/OracleDevartHealthCheckTests.cs
@@ -7,7 +7,7 @@ using Microsoft.Extensions.Diagnostics.HealthChecks;
 using Microsoft.Extensions.Options;
 using NetEvolve.Extensions.TUnit;
 using NetEvolve.HealthChecks.Oracle.Devart;
-using NSubstitute;
+using TUnit.Mocks;
 
 [TestGroup($"{nameof(Oracle)}.{nameof(Devart)}")]
 public sealed class OracleDevartHealthCheckTests
@@ -18,7 +18,7 @@ public sealed class OracleDevartHealthCheckTests
     public async Task CheckHealthAsync_WhenContextNull_ThrowArgumentNullException()
     {
         // Arrange
-        var optionsMonitor = Substitute.For<IOptionsMonitor<OracleDevartOptions>>();
+        var optionsMonitor = IOptionsMonitor<OracleDevartOptions>.Mock();
         var check = new OracleDevartHealthCheck(optionsMonitor);
 
         // Act
@@ -32,7 +32,7 @@ public sealed class OracleDevartHealthCheckTests
     public async Task CheckHealthAsync_WhenCancellationTokenIsCancelled_ShouldReturnUnhealthy()
     {
         // Arrange
-        var optionsMonitor = Substitute.For<IOptionsMonitor<OracleDevartOptions>>();
+        var optionsMonitor = IOptionsMonitor<OracleDevartOptions>.Mock();
         var check = new OracleDevartHealthCheck(optionsMonitor);
         var context = new HealthCheckContext
         {
@@ -55,7 +55,7 @@ public sealed class OracleDevartHealthCheckTests
     public async Task CheckHealthAsync_WhenOptionsAreNull_ShouldReturnUnhealthy()
     {
         // Arrange
-        var optionsMonitor = Substitute.For<IOptionsMonitor<OracleDevartOptions>>();
+        var optionsMonitor = IOptionsMonitor<OracleDevartOptions>.Mock();
         var check = new OracleDevartHealthCheck(optionsMonitor);
         var context = new HealthCheckContext
         {

--- a/tests/NetEvolve.HealthChecks.Tests.Unit/Oracle/OracleHealthCheckTests.cs
+++ b/tests/NetEvolve.HealthChecks.Tests.Unit/Oracle/OracleHealthCheckTests.cs
@@ -7,7 +7,7 @@ using Microsoft.Extensions.Diagnostics.HealthChecks;
 using Microsoft.Extensions.Options;
 using NetEvolve.Extensions.TUnit;
 using NetEvolve.HealthChecks.Oracle;
-using NSubstitute;
+using TUnit.Mocks;
 
 [TestGroup(nameof(Oracle))]
 public sealed class OracleHealthCheckTests
@@ -18,7 +18,7 @@ public sealed class OracleHealthCheckTests
     public async Task CheckHealthAsync_WhenContextNull_ThrowArgumentNullException()
     {
         // Arrange
-        var optionsMonitor = Substitute.For<IOptionsMonitor<OracleOptions>>();
+        var optionsMonitor = IOptionsMonitor<OracleOptions>.Mock();
         var check = new OracleHealthCheck(optionsMonitor);
 
         // Act
@@ -32,7 +32,7 @@ public sealed class OracleHealthCheckTests
     public async Task CheckHealthAsync_WhenCancellationTokenIsCancelled_ShouldReturnUnhealthy()
     {
         // Arrange
-        var optionsMonitor = Substitute.For<IOptionsMonitor<OracleOptions>>();
+        var optionsMonitor = IOptionsMonitor<OracleOptions>.Mock();
         var check = new OracleHealthCheck(optionsMonitor);
         var context = new HealthCheckContext
         {
@@ -55,7 +55,7 @@ public sealed class OracleHealthCheckTests
     public async Task CheckHealthAsync_WhenOptionsAreNull_ShouldReturnUnhealthy()
     {
         // Arrange
-        var optionsMonitor = Substitute.For<IOptionsMonitor<OracleOptions>>();
+        var optionsMonitor = IOptionsMonitor<OracleOptions>.Mock();
         var check = new OracleHealthCheck(optionsMonitor);
         var context = new HealthCheckContext
         {

--- a/tests/NetEvolve.HealthChecks.Tests.Unit/Qdrant/QdrantHealthCheckTests.cs
+++ b/tests/NetEvolve.HealthChecks.Tests.Unit/Qdrant/QdrantHealthCheckTests.cs
@@ -7,7 +7,7 @@ using Microsoft.Extensions.Diagnostics.HealthChecks;
 using Microsoft.Extensions.Options;
 using NetEvolve.Extensions.TUnit;
 using NetEvolve.HealthChecks.Qdrant;
-using NSubstitute;
+using TUnit.Mocks;
 
 [TestGroup(nameof(Qdrant))]
 public sealed class QdrantHealthCheckTests
@@ -18,8 +18,8 @@ public sealed class QdrantHealthCheckTests
     public async Task CheckHealthAsync_WhenContextNull_ThrowArgumentNullException()
     {
         // Arrange
-        var optionsMonitor = Substitute.For<IOptionsMonitor<QdrantOptions>>();
-        var serviceProvider = Substitute.For<IServiceProvider>();
+        var optionsMonitor = IOptionsMonitor<QdrantOptions>.Mock();
+        var serviceProvider = IServiceProvider.Mock();
         var check = new QdrantHealthCheck(serviceProvider, optionsMonitor);
 
         // Act
@@ -33,8 +33,8 @@ public sealed class QdrantHealthCheckTests
     public async Task CheckHealthAsync_WhenCancellationTokenIsCancelled_ShouldReturnUnhealthy()
     {
         // Arrange
-        var optionsMonitor = Substitute.For<IOptionsMonitor<QdrantOptions>>();
-        var serviceProvider = Substitute.For<IServiceProvider>();
+        var optionsMonitor = IOptionsMonitor<QdrantOptions>.Mock();
+        var serviceProvider = IServiceProvider.Mock();
         var check = new QdrantHealthCheck(serviceProvider, optionsMonitor);
         var context = new HealthCheckContext
         {
@@ -57,8 +57,8 @@ public sealed class QdrantHealthCheckTests
     public async Task CheckHealthAsync_WhenOptionsAreNull_ShouldReturnUnhealthy()
     {
         // Arrange
-        var optionsMonitor = Substitute.For<IOptionsMonitor<QdrantOptions>>();
-        var serviceProvider = Substitute.For<IServiceProvider>();
+        var optionsMonitor = IOptionsMonitor<QdrantOptions>.Mock();
+        var serviceProvider = IServiceProvider.Mock();
         var check = new QdrantHealthCheck(serviceProvider, optionsMonitor);
         var context = new HealthCheckContext
         {

--- a/tests/NetEvolve.HealthChecks.Tests.Unit/QuestDB/QuestDBHealthCheckTests.cs
+++ b/tests/NetEvolve.HealthChecks.Tests.Unit/QuestDB/QuestDBHealthCheckTests.cs
@@ -7,7 +7,7 @@ using Microsoft.Extensions.Diagnostics.HealthChecks;
 using Microsoft.Extensions.Options;
 using NetEvolve.Extensions.TUnit;
 using NetEvolve.HealthChecks.QuestDB;
-using NSubstitute;
+using TUnit.Mocks;
 
 [TestGroup(nameof(QuestDB))]
 public sealed class QuestDBHealthCheckTests
@@ -18,8 +18,8 @@ public sealed class QuestDBHealthCheckTests
     public async Task CheckHealthAsync_WhenContextNull_ThrowArgumentNullException()
     {
         // Arrange
-        var optionsMonitor = Substitute.For<IOptionsMonitor<QuestDBOptions>>();
-        var serviceProvider = Substitute.For<IServiceProvider>();
+        var optionsMonitor = IOptionsMonitor<QuestDBOptions>.Mock();
+        var serviceProvider = IServiceProvider.Mock();
         var check = new QuestDBHealthCheck(serviceProvider, optionsMonitor);
 
         // Act
@@ -33,8 +33,8 @@ public sealed class QuestDBHealthCheckTests
     public async Task CheckHealthAsync_WhenCancellationTokenIsCancelled_ShouldReturnUnhealthy()
     {
         // Arrange
-        var optionsMonitor = Substitute.For<IOptionsMonitor<QuestDBOptions>>();
-        var serviceProvider = Substitute.For<IServiceProvider>();
+        var optionsMonitor = IOptionsMonitor<QuestDBOptions>.Mock();
+        var serviceProvider = IServiceProvider.Mock();
         var check = new QuestDBHealthCheck(serviceProvider, optionsMonitor);
         var context = new HealthCheckContext
         {
@@ -57,8 +57,8 @@ public sealed class QuestDBHealthCheckTests
     public async Task CheckHealthAsync_WhenOptionsAreNull_ShouldReturnUnhealthy()
     {
         // Arrange
-        var optionsMonitor = Substitute.For<IOptionsMonitor<QuestDBOptions>>();
-        var serviceProvider = Substitute.For<IServiceProvider>();
+        var optionsMonitor = IOptionsMonitor<QuestDBOptions>.Mock();
+        var serviceProvider = IServiceProvider.Mock();
         var check = new QuestDBHealthCheck(serviceProvider, optionsMonitor);
         var context = new HealthCheckContext
         {

--- a/tests/NetEvolve.HealthChecks.Tests.Unit/RabbitMQ/RabbitMQHealthCheckTests.cs
+++ b/tests/NetEvolve.HealthChecks.Tests.Unit/RabbitMQ/RabbitMQHealthCheckTests.cs
@@ -11,7 +11,7 @@ using Microsoft.Extensions.Options;
 using NetEvolve.Extensions.TUnit;
 using NetEvolve.HealthChecks.RabbitMQ;
 using NSubstitute;
-using NSubstitute.ExceptionExtensions;
+using TUnit.Mocks;
 
 [TestGroup(nameof(RabbitMQ))]
 public sealed class RabbitMQHealthCheckTests
@@ -29,19 +29,17 @@ public sealed class RabbitMQHealthCheckTests
         // Arrange
         var options = new RabbitMQOptions { KeyedService = "test-key", Timeout = 10000 };
 
-        var optionsMonitor = Substitute.For<IOptionsMonitor<RabbitMQOptions>>();
+        var optionsMonitor = IOptionsMonitor<RabbitMQOptions>.Mock();
         _ = optionsMonitor.Get(TestName).Returns(options);
 
         // Setup connection mock that returns success
-        var mockChannel = Substitute.For<IChannel>();
+        var mockChannel = IChannel.Mock();
         _ = mockChannel.IsOpen.Returns(true);
-        var mockConnection = Substitute.For<IConnection>();
-        _ = mockConnection
-            .CreateChannelAsync(Arg.Any<CreateChannelOptions>(), Arg.Any<CancellationToken>())
-            .Returns(Task.FromResult(mockChannel));
+        var mockConnection = IConnection.Mock();
+        _ = mockConnection.CreateChannelAsync(Any(), Any()).Returns(mockChannel);
 
         var serviceCollection = new ServiceCollection();
-        _ = serviceCollection.AddKeyedSingleton("test-key", mockConnection);
+        _ = serviceCollection.AddKeyedSingleton<IConnection>("test-key", mockConnection);
         var serviceProvider = serviceCollection.BuildServiceProvider();
 
         var healthCheck = new RabbitMQHealthCheck(serviceProvider, optionsMonitor);
@@ -72,19 +70,17 @@ public sealed class RabbitMQHealthCheckTests
         // Arrange
         var options = new RabbitMQOptions { KeyedService = null, Timeout = 1000 };
 
-        var optionsMonitor = Substitute.For<IOptionsMonitor<RabbitMQOptions>>();
+        var optionsMonitor = IOptionsMonitor<RabbitMQOptions>.Mock();
         _ = optionsMonitor.Get(TestName).Returns(options);
 
         // Setup connection mock that returns success
-        var mockChannel = Substitute.For<IChannel>();
+        var mockChannel = IChannel.Mock();
         _ = mockChannel.IsOpen.Returns(true);
-        var mockConnection = Substitute.For<IConnection>();
-        _ = mockConnection
-            .CreateChannelAsync(Arg.Any<CreateChannelOptions>(), Arg.Any<CancellationToken>())
-            .Returns(Task.FromResult(mockChannel));
+        var mockConnection = IConnection.Mock();
+        _ = mockConnection.CreateChannelAsync(Any(), Any()).Returns(mockChannel);
 
         var serviceCollection = new ServiceCollection();
-        _ = serviceCollection.AddSingleton(mockConnection);
+        _ = serviceCollection.AddSingleton<IConnection>(mockConnection);
         var serviceProvider = serviceCollection.BuildServiceProvider();
 
         var healthCheck = new RabbitMQHealthCheck(serviceProvider, optionsMonitor);
@@ -110,17 +106,17 @@ public sealed class RabbitMQHealthCheckTests
         // Arrange
         var options = new RabbitMQOptions { KeyedService = null, Timeout = 1000 };
 
-        var optionsMonitor = Substitute.For<IOptionsMonitor<RabbitMQOptions>>();
+        var optionsMonitor = IOptionsMonitor<RabbitMQOptions>.Mock();
         _ = optionsMonitor.Get(TestName).Returns(options);
 
         // Setup connection mock that throws an exception
-        var mockConnection = Substitute.For<IConnection>();
+        var mockConnection = IConnection.Mock();
         _ = mockConnection
-            .CreateChannelAsync(Arg.Any<CreateChannelOptions>(), Arg.Any<CancellationToken>())
-            .ThrowsAsync(new InvalidOperationException("Connection failed"));
+            .CreateChannelAsync(Any(), Any())
+            .Throws(new InvalidOperationException("Connection failed"));
 
         var serviceCollection = new ServiceCollection();
-        _ = serviceCollection.AddSingleton(mockConnection);
+        _ = serviceCollection.AddSingleton<IConnection>(mockConnection);
         var serviceProvider = serviceCollection.BuildServiceProvider();
 
         var healthCheck = new RabbitMQHealthCheck(serviceProvider, optionsMonitor);
@@ -153,15 +149,19 @@ public sealed class RabbitMQHealthCheckTests
             Timeout = 1, // Very short timeout to force a timeout
         };
 
-        var optionsMonitor = Substitute.For<IOptionsMonitor<RabbitMQOptions>>();
+        // TUnit.Mocks' .Returns() only supports a synchronous Func<T> (auto-wrapped into a
+        // completed Task<T>) - there's no way to hand back a task that stays pending and
+        // completes asynchronously later, so a genuine timeout-race can't be simulated with it.
+        // NSubstitute is used here instead, purely for this one test.
+        var optionsMonitor = NSubstitute.Substitute.For<IOptionsMonitor<RabbitMQOptions>>();
         _ = optionsMonitor.Get(TestName).Returns(options);
 
         // Setup connection mock that delays long enough to cause timeout
-        var mockChannel = Substitute.For<IChannel>();
+        var mockChannel = NSubstitute.Substitute.For<IChannel>();
         _ = mockChannel.IsOpen.Returns(true);
-        var mockConnection = Substitute.For<IConnection>();
+        var mockConnection = NSubstitute.Substitute.For<IConnection>();
         _ = mockConnection
-            .CreateChannelAsync(Arg.Any<CreateChannelOptions>(), Arg.Any<CancellationToken>())
+            .CreateChannelAsync(NSubstitute.Arg.Any<CreateChannelOptions>(), NSubstitute.Arg.Any<CancellationToken>())
             .Returns(async _ =>
             {
                 await Task.Delay(50); // Delay to force timeout

--- a/tests/NetEvolve.HealthChecks.Tests.Unit/RabbitMQ/RabbitMQHealthCheckTests.cs
+++ b/tests/NetEvolve.HealthChecks.Tests.Unit/RabbitMQ/RabbitMQHealthCheckTests.cs
@@ -111,9 +111,7 @@ public sealed class RabbitMQHealthCheckTests
 
         // Setup connection mock that throws an exception
         var mockConnection = IConnection.Mock();
-        _ = mockConnection
-            .CreateChannelAsync(Any(), Any())
-            .Throws(new InvalidOperationException("Connection failed"));
+        _ = mockConnection.CreateChannelAsync(Any(), Any()).Throws(new InvalidOperationException("Connection failed"));
 
         var serviceCollection = new ServiceCollection();
         _ = serviceCollection.AddSingleton<IConnection>(mockConnection);

--- a/tests/NetEvolve.HealthChecks.Tests.Unit/Redis/RedisHealthCheckTests.cs
+++ b/tests/NetEvolve.HealthChecks.Tests.Unit/Redis/RedisHealthCheckTests.cs
@@ -7,7 +7,7 @@ using Microsoft.Extensions.Diagnostics.HealthChecks;
 using Microsoft.Extensions.Options;
 using NetEvolve.Extensions.TUnit;
 using NetEvolve.HealthChecks.Redis;
-using NSubstitute;
+using TUnit.Mocks;
 
 [TestGroup(nameof(Redis))]
 public sealed class RedisHealthCheckTests
@@ -18,8 +18,8 @@ public sealed class RedisHealthCheckTests
     public async Task CheckHealthAsync_WhenContextNull_ThrowArgumentNullException()
     {
         // Arrange
-        var serviceProvider = Substitute.For<IServiceProvider>();
-        var optionsMonitor = Substitute.For<IOptionsMonitor<RedisOptions>>();
+        var serviceProvider = IServiceProvider.Mock();
+        var optionsMonitor = IOptionsMonitor<RedisOptions>.Mock();
         using var check = new RedisHealthCheck(serviceProvider, optionsMonitor);
 
         // Act
@@ -33,8 +33,8 @@ public sealed class RedisHealthCheckTests
     public async Task CheckHealthAsync_WhenCancellationTokenIsCancelled_ShouldReturnUnhealthy()
     {
         // Arrange
-        var serviceProvider = Substitute.For<IServiceProvider>();
-        var optionsMonitor = Substitute.For<IOptionsMonitor<RedisOptions>>();
+        var serviceProvider = IServiceProvider.Mock();
+        var optionsMonitor = IOptionsMonitor<RedisOptions>.Mock();
         using var check = new RedisHealthCheck(serviceProvider, optionsMonitor);
         var context = new HealthCheckContext
         {
@@ -57,8 +57,8 @@ public sealed class RedisHealthCheckTests
     public async Task CheckHealthAsync_WhenOptionsAreNull_ShouldReturnUnhealthy()
     {
         // Arrange
-        var serviceProvider = Substitute.For<IServiceProvider>();
-        var optionsMonitor = Substitute.For<IOptionsMonitor<RedisOptions>>();
+        var serviceProvider = IServiceProvider.Mock();
+        var optionsMonitor = IOptionsMonitor<RedisOptions>.Mock();
         using var check = new RedisHealthCheck(serviceProvider, optionsMonitor);
         var context = new HealthCheckContext
         {

--- a/tests/NetEvolve.HealthChecks.Tests.Unit/Redpanda/RedpandaHealthCheckTests.cs
+++ b/tests/NetEvolve.HealthChecks.Tests.Unit/Redpanda/RedpandaHealthCheckTests.cs
@@ -7,7 +7,7 @@ using Microsoft.Extensions.Diagnostics.HealthChecks;
 using Microsoft.Extensions.Options;
 using NetEvolve.Extensions.TUnit;
 using NetEvolve.HealthChecks.Redpanda;
-using NSubstitute;
+using TUnit.Mocks;
 
 [TestGroup(nameof(Redpanda))]
 public sealed class RedpandaHealthCheckTests
@@ -18,8 +18,8 @@ public sealed class RedpandaHealthCheckTests
     public async Task CheckHealthAsync_WhenContextNull_ThrowArgumentNullException()
     {
         // Arrange
-        var optionsMonitor = Substitute.For<IOptionsMonitor<RedpandaOptions>>();
-        var serviceProvider = Substitute.For<IServiceProvider>();
+        var optionsMonitor = IOptionsMonitor<RedpandaOptions>.Mock();
+        var serviceProvider = IServiceProvider.Mock();
         using var check = new RedpandaHealthCheck(serviceProvider, optionsMonitor);
 
         // Act
@@ -33,8 +33,8 @@ public sealed class RedpandaHealthCheckTests
     public async Task CheckHealthAsync_WhenCancellationTokenIsCancelled_ShouldReturnUnhealthy()
     {
         // Arrange
-        var optionsMonitor = Substitute.For<IOptionsMonitor<RedpandaOptions>>();
-        var serviceProvider = Substitute.For<IServiceProvider>();
+        var optionsMonitor = IOptionsMonitor<RedpandaOptions>.Mock();
+        var serviceProvider = IServiceProvider.Mock();
         using var check = new RedpandaHealthCheck(serviceProvider, optionsMonitor);
         var context = new HealthCheckContext
         {
@@ -57,8 +57,8 @@ public sealed class RedpandaHealthCheckTests
     public async Task CheckHealthAsync_WhenOptionsAreNull_ShouldReturnUnhealthy()
     {
         // Arrange
-        var optionsMonitor = Substitute.For<IOptionsMonitor<RedpandaOptions>>();
-        var serviceProvider = Substitute.For<IServiceProvider>();
+        var optionsMonitor = IOptionsMonitor<RedpandaOptions>.Mock();
+        var serviceProvider = IServiceProvider.Mock();
         using var check = new RedpandaHealthCheck(serviceProvider, optionsMonitor);
         var context = new HealthCheckContext
         {

--- a/tests/NetEvolve.HealthChecks.Tests.Unit/SQLite.Devart/SQLiteDevartHealthCheckTests.cs
+++ b/tests/NetEvolve.HealthChecks.Tests.Unit/SQLite.Devart/SQLiteDevartHealthCheckTests.cs
@@ -7,7 +7,7 @@ using Microsoft.Extensions.Diagnostics.HealthChecks;
 using Microsoft.Extensions.Options;
 using NetEvolve.Extensions.TUnit;
 using NetEvolve.HealthChecks.SQLite.Devart;
-using NSubstitute;
+using TUnit.Mocks;
 
 [TestGroup($"{nameof(SQLite)}.{nameof(Devart)}")]
 public sealed class SQLiteDevartHealthCheckTests
@@ -18,7 +18,7 @@ public sealed class SQLiteDevartHealthCheckTests
     public async Task CheckHealthAsync_WhenContextNull_ThrowArgumentNullException()
     {
         // Arrange
-        var optionsMonitor = Substitute.For<IOptionsMonitor<SQLiteDevartOptions>>();
+        var optionsMonitor = IOptionsMonitor<SQLiteDevartOptions>.Mock();
         var check = new SQLiteDevartHealthCheck(optionsMonitor);
 
         // Act
@@ -32,7 +32,7 @@ public sealed class SQLiteDevartHealthCheckTests
     public async Task CheckHealthAsync_WhenCancellationTokenIsCancelled_ShouldReturnUnhealthy()
     {
         // Arrange
-        var optionsMonitor = Substitute.For<IOptionsMonitor<SQLiteDevartOptions>>();
+        var optionsMonitor = IOptionsMonitor<SQLiteDevartOptions>.Mock();
         var check = new SQLiteDevartHealthCheck(optionsMonitor);
         var context = new HealthCheckContext
         {
@@ -55,7 +55,7 @@ public sealed class SQLiteDevartHealthCheckTests
     public async Task CheckHealthAsync_WhenOptionsAreNull_ShouldReturnUnhealthy()
     {
         // Arrange
-        var optionsMonitor = Substitute.For<IOptionsMonitor<SQLiteDevartOptions>>();
+        var optionsMonitor = IOptionsMonitor<SQLiteDevartOptions>.Mock();
         var check = new SQLiteDevartHealthCheck(optionsMonitor);
         var context = new HealthCheckContext
         {

--- a/tests/NetEvolve.HealthChecks.Tests.Unit/SQLite.Legacy/SQLiteLegacyHealthCheckTests.cs
+++ b/tests/NetEvolve.HealthChecks.Tests.Unit/SQLite.Legacy/SQLiteLegacyHealthCheckTests.cs
@@ -7,7 +7,7 @@ using Microsoft.Extensions.Diagnostics.HealthChecks;
 using Microsoft.Extensions.Options;
 using NetEvolve.Extensions.TUnit;
 using NetEvolve.HealthChecks.SQLite.Legacy;
-using NSubstitute;
+using TUnit.Mocks;
 
 [TestGroup($"{nameof(SQLite)}.{nameof(Legacy)}")]
 public sealed class SQLiteLegacyHealthCheckTests
@@ -18,7 +18,7 @@ public sealed class SQLiteLegacyHealthCheckTests
     public async Task CheckHealthAsync_WhenContextNull_ThrowArgumentNullException()
     {
         // Arrange
-        var optionsMonitor = Substitute.For<IOptionsMonitor<SQLiteLegacyOptions>>();
+        var optionsMonitor = IOptionsMonitor<SQLiteLegacyOptions>.Mock();
         var check = new SQLiteLegacyHealthCheck(optionsMonitor);
 
         // Act
@@ -32,7 +32,7 @@ public sealed class SQLiteLegacyHealthCheckTests
     public async Task CheckHealthAsync_WhenCancellationTokenIsCancelled_ShouldReturnUnhealthy()
     {
         // Arrange
-        var optionsMonitor = Substitute.For<IOptionsMonitor<SQLiteLegacyOptions>>();
+        var optionsMonitor = IOptionsMonitor<SQLiteLegacyOptions>.Mock();
         var check = new SQLiteLegacyHealthCheck(optionsMonitor);
         var context = new HealthCheckContext
         {
@@ -55,7 +55,7 @@ public sealed class SQLiteLegacyHealthCheckTests
     public async Task CheckHealthAsync_WhenOptionsAreNull_ShouldReturnUnhealthy()
     {
         // Arrange
-        var optionsMonitor = Substitute.For<IOptionsMonitor<SQLiteLegacyOptions>>();
+        var optionsMonitor = IOptionsMonitor<SQLiteLegacyOptions>.Mock();
         var check = new SQLiteLegacyHealthCheck(optionsMonitor);
         var context = new HealthCheckContext
         {

--- a/tests/NetEvolve.HealthChecks.Tests.Unit/SQLite/SQLiteHealthCheckTests.cs
+++ b/tests/NetEvolve.HealthChecks.Tests.Unit/SQLite/SQLiteHealthCheckTests.cs
@@ -7,7 +7,7 @@ using Microsoft.Extensions.Diagnostics.HealthChecks;
 using Microsoft.Extensions.Options;
 using NetEvolve.Extensions.TUnit;
 using NetEvolve.HealthChecks.SQLite;
-using NSubstitute;
+using TUnit.Mocks;
 
 [TestGroup(nameof(SQLite))]
 public sealed class SQLiteHealthCheckTests
@@ -18,7 +18,7 @@ public sealed class SQLiteHealthCheckTests
     public async Task CheckHealthAsync_WhenContextNull_ThrowArgumentNullException()
     {
         // Arrange
-        var optionsMonitor = Substitute.For<IOptionsMonitor<SQLiteOptions>>();
+        var optionsMonitor = IOptionsMonitor<SQLiteOptions>.Mock();
         var check = new SQLiteHealthCheck(optionsMonitor);
 
         // Act
@@ -32,7 +32,7 @@ public sealed class SQLiteHealthCheckTests
     public async Task CheckHealthAsync_WhenCancellationTokenIsCancelled_ShouldReturnUnhealthy()
     {
         // Arrange
-        var optionsMonitor = Substitute.For<IOptionsMonitor<SQLiteOptions>>();
+        var optionsMonitor = IOptionsMonitor<SQLiteOptions>.Mock();
         var check = new SQLiteHealthCheck(optionsMonitor);
         var context = new HealthCheckContext
         {
@@ -55,7 +55,7 @@ public sealed class SQLiteHealthCheckTests
     public async Task CheckHealthAsync_WhenOptionsAreNull_ShouldReturnUnhealthy()
     {
         // Arrange
-        var optionsMonitor = Substitute.For<IOptionsMonitor<SQLiteOptions>>();
+        var optionsMonitor = IOptionsMonitor<SQLiteOptions>.Mock();
         var check = new SQLiteHealthCheck(optionsMonitor);
         var context = new HealthCheckContext
         {

--- a/tests/NetEvolve.HealthChecks.Tests.Unit/SqlServer.Devart/SqlServerDevartHealthCheckTests.cs
+++ b/tests/NetEvolve.HealthChecks.Tests.Unit/SqlServer.Devart/SqlServerDevartHealthCheckTests.cs
@@ -7,7 +7,7 @@ using Microsoft.Extensions.Diagnostics.HealthChecks;
 using Microsoft.Extensions.Options;
 using NetEvolve.Extensions.TUnit;
 using NetEvolve.HealthChecks.SqlServer.Devart;
-using NSubstitute;
+using TUnit.Mocks;
 
 [TestGroup($"{nameof(SqlServer)}.{nameof(Devart)}")]
 public sealed class SqlServerDevartHealthCheckTests
@@ -18,7 +18,7 @@ public sealed class SqlServerDevartHealthCheckTests
     public async Task CheckHealthAsync_WhenContextNull_ThrowArgumentNullException()
     {
         // Arrange
-        var optionsMonitor = Substitute.For<IOptionsMonitor<SqlServerDevartOptions>>();
+        var optionsMonitor = IOptionsMonitor<SqlServerDevartOptions>.Mock();
         var check = new SqlServerDevartHealthCheck(optionsMonitor);
 
         // Act
@@ -32,7 +32,7 @@ public sealed class SqlServerDevartHealthCheckTests
     public async Task CheckHealthAsync_WhenCancellationTokenIsCancelled_ShouldReturnUnhealthy()
     {
         // Arrange
-        var optionsMonitor = Substitute.For<IOptionsMonitor<SqlServerDevartOptions>>();
+        var optionsMonitor = IOptionsMonitor<SqlServerDevartOptions>.Mock();
         var check = new SqlServerDevartHealthCheck(optionsMonitor);
         var context = new HealthCheckContext
         {
@@ -55,7 +55,7 @@ public sealed class SqlServerDevartHealthCheckTests
     public async Task CheckHealthAsync_WhenOptionsAreNull_ShouldReturnUnhealthy()
     {
         // Arrange
-        var optionsMonitor = Substitute.For<IOptionsMonitor<SqlServerDevartOptions>>();
+        var optionsMonitor = IOptionsMonitor<SqlServerDevartOptions>.Mock();
         var check = new SqlServerDevartHealthCheck(optionsMonitor);
         var context = new HealthCheckContext
         {

--- a/tests/NetEvolve.HealthChecks.Tests.Unit/SqlServer.Legacy/SqlServerLegacyHealthCheckTests.cs
+++ b/tests/NetEvolve.HealthChecks.Tests.Unit/SqlServer.Legacy/SqlServerLegacyHealthCheckTests.cs
@@ -7,7 +7,7 @@ using Microsoft.Extensions.Diagnostics.HealthChecks;
 using Microsoft.Extensions.Options;
 using NetEvolve.Extensions.TUnit;
 using NetEvolve.HealthChecks.SqlServer.Legacy;
-using NSubstitute;
+using TUnit.Mocks;
 
 [TestGroup($"{nameof(SqlServer)}.{nameof(Legacy)}")]
 public sealed class SqlServerLegacyHealthCheckTests
@@ -18,7 +18,7 @@ public sealed class SqlServerLegacyHealthCheckTests
     public async Task CheckHealthAsync_WhenContextNull_ThrowArgumentNullException()
     {
         // Arrange
-        var optionsMonitor = Substitute.For<IOptionsMonitor<SqlServerLegacyOptions>>();
+        var optionsMonitor = IOptionsMonitor<SqlServerLegacyOptions>.Mock();
         var check = new SqlServerLegacyHealthCheck(optionsMonitor);
 
         // Act
@@ -32,7 +32,7 @@ public sealed class SqlServerLegacyHealthCheckTests
     public async Task CheckHealthAsync_WhenCancellationTokenIsCancelled_ShouldReturnUnhealthy()
     {
         // Arrange
-        var optionsMonitor = Substitute.For<IOptionsMonitor<SqlServerLegacyOptions>>();
+        var optionsMonitor = IOptionsMonitor<SqlServerLegacyOptions>.Mock();
         var check = new SqlServerLegacyHealthCheck(optionsMonitor);
         var context = new HealthCheckContext
         {
@@ -55,7 +55,7 @@ public sealed class SqlServerLegacyHealthCheckTests
     public async Task CheckHealthAsync_WhenOptionsAreNull_ShouldReturnUnhealthy()
     {
         // Arrange
-        var optionsMonitor = Substitute.For<IOptionsMonitor<SqlServerLegacyOptions>>();
+        var optionsMonitor = IOptionsMonitor<SqlServerLegacyOptions>.Mock();
         var check = new SqlServerLegacyHealthCheck(optionsMonitor);
         var context = new HealthCheckContext
         {

--- a/tests/NetEvolve.HealthChecks.Tests.Unit/SqlServer/SqlServerHealthCheckTests.cs
+++ b/tests/NetEvolve.HealthChecks.Tests.Unit/SqlServer/SqlServerHealthCheckTests.cs
@@ -7,7 +7,7 @@ using Microsoft.Extensions.Diagnostics.HealthChecks;
 using Microsoft.Extensions.Options;
 using NetEvolve.Extensions.TUnit;
 using NetEvolve.HealthChecks.SqlServer;
-using NSubstitute;
+using TUnit.Mocks;
 
 [TestGroup(nameof(SqlServer))]
 public sealed class SqlServerHealthCheckTests
@@ -18,7 +18,7 @@ public sealed class SqlServerHealthCheckTests
     public async Task CheckHealthAsync_WhenContextNull_ThrowArgumentNullException()
     {
         // Arrange
-        var optionsMonitor = Substitute.For<IOptionsMonitor<SqlServerOptions>>();
+        var optionsMonitor = IOptionsMonitor<SqlServerOptions>.Mock();
         var check = new SqlServerHealthCheck(optionsMonitor);
 
         // Act
@@ -32,7 +32,7 @@ public sealed class SqlServerHealthCheckTests
     public async Task CheckHealthAsync_WhenCancellationTokenIsCancelled_ShouldReturnUnhealthy()
     {
         // Arrange
-        var optionsMonitor = Substitute.For<IOptionsMonitor<SqlServerOptions>>();
+        var optionsMonitor = IOptionsMonitor<SqlServerOptions>.Mock();
         var check = new SqlServerHealthCheck(optionsMonitor);
         var context = new HealthCheckContext
         {
@@ -55,7 +55,7 @@ public sealed class SqlServerHealthCheckTests
     public async Task CheckHealthAsync_WhenOptionsAreNull_ShouldReturnUnhealthy()
     {
         // Arrange
-        var optionsMonitor = Substitute.For<IOptionsMonitor<SqlServerOptions>>();
+        var optionsMonitor = IOptionsMonitor<SqlServerOptions>.Mock();
         var check = new SqlServerHealthCheck(optionsMonitor);
         var context = new HealthCheckContext
         {


### PR DESCRIPTION
## Summary

- Replaces NSubstitute with [TUnit.Mocks](https://tunit.dev/docs/writing-tests/mocking/) (source-generated, AOT-compatible mocking) in 60 of 67 files in `NetEvolve.HealthChecks.Tests.Unit`, consolidating onto the TUnit ecosystem already used as this project's test framework.
- Closes #2049.

## Scoped exceptions

7 files remain on NSubstitute due to genuine limitations in TUnit.Mocks 1.61.38 (currently the latest, alpha-quality) that aren't fixable from test code. Each is documented in the csproj and filed upstream:

| File(s) | Root cause | Upstream issue |
|---|---|---|
| `RavenDb/RavenDbHealthCheckTests.cs` | Generator bug mocking `IDocumentStore` (asymmetric property accessor on a nested member, CS0535/CS0548/CS0551) | [thomhurst/TUnit#6491](https://github.com/thomhurst/TUnit/issues/6491) |
| `Elasticsearch/ElasticsearchHealthCheckTests.cs` | Generator bug mocking `ElasticsearchClientSettings` (invalid nullable-type pattern, CS8116) | [thomhurst/TUnit#6492](https://github.com/thomhurst/TUnit/issues/6492) |
| `Azure.ServiceBus/Service­Bus{Queue,Subscription,Topic}AdministrationTests.cs` | Mocking `ServiceBusAdministrationClient` pulls in `*RuntimeProperties` types that have no accessible parameterless constructor (CS1729) | [thomhurst/TUnit#6493](https://github.com/thomhurst/TUnit/issues/6493) |
| `Cassandra/CassandraHealthCheckTests.cs` | Generated wrapper type name `IClusterMock` collides with Couchbase's `ICluster` (also mocked in this project) — the generator doesn't namespace-qualify wrapper names | [thomhurst/TUnit#6494](https://github.com/thomhurst/TUnit/issues/6494) |
| `RabbitMQ/RabbitMQHealthCheckTests.cs` (one test) | `.Returns()` only accepts a synchronous `Func<T>`, so a mocked async call can't stay genuinely pending — breaks a timeout-race test | [thomhurst/TUnit#6495](https://github.com/thomhurst/TUnit/issues/6495) |

All 7 files carry an explanatory comment in the csproj and can be migrated once the upstream issues are resolved.

## Test plan

- [x] `dotnet build` — 0 warnings, 0 errors (net10.0)
- [x] `dotnet test` (Tests.Unit) — 1861/1861 passed
- [x] `dotnet test` (Tests.Architecture) — 6/6 passed
- [x] Verified each Pile-A exception with a minimal, isolated repro before filing upstream (ruled out one false positive — Cassandra initially looked like a generator limitation but was in fact the namespace-collision bug above)

🤖 Generated with [Claude Code](https://claude.com/claude-code)