### PR TITLE
fix(rabbitmq): dispose channel created during health check

### DIFF
--- a/src/NetEvolve.HealthChecks.RabbitMQ/RabbitMQHealthCheck.cs
+++ b/src/NetEvolve.HealthChecks.RabbitMQ/RabbitMQHealthCheck.cs
@@ -31,11 +31,21 @@ internal sealed partial class RabbitMQHealthCheck
             .WithTimeoutAsync(options.Timeout, cancellationToken)
             .ConfigureAwait(false);
 
-        if (channel?.IsOpen != true)
+        try
         {
-            return HealthCheckUnhealthy(failureStatus, name, "Failed to create a channel to RabbitMQ.");
-        }
+            if (channel?.IsOpen != true)
+            {
+                return HealthCheckUnhealthy(failureStatus, name, "Failed to create a channel to RabbitMQ.");
+            }
 
-        return HealthCheckState(isTimelyResponse, name);
+            return HealthCheckState(isTimelyResponse, name);
+        }
+        finally
+        {
+            if (channel is not null)
+            {
+                await channel.DisposeAsync().ConfigureAwait(false);
+            }
+        }
     }
 }

--- a/tests/NetEvolve.HealthChecks.Tests.Unit/RabbitMQ/RabbitMQHealthCheckTests.cs
+++ b/tests/NetEvolve.HealthChecks.Tests.Unit/RabbitMQ/RabbitMQHealthCheckTests.cs
@@ -142,6 +142,85 @@ public sealed class RabbitMQHealthCheckTests
         "CA2025:Do not pass 'IDisposable' instances into unawaited tasks",
         Justification = "As designed."
     )]
+    public async Task CheckHealthAsync_WithoutKeyedService_DisposesChannel()
+    {
+        // Arrange
+        var options = new RabbitMQOptions { KeyedService = null, Timeout = 1000 };
+
+        var optionsMonitor = IOptionsMonitor<RabbitMQOptions>.Mock();
+        _ = optionsMonitor.Get(TestName).Returns(options);
+
+        var mockChannel = IChannel.Mock();
+        _ = mockChannel.IsOpen.Returns(true);
+        var mockConnection = IConnection.Mock();
+        _ = mockConnection.CreateChannelAsync(Any(), Any()).Returns(mockChannel);
+
+        var serviceCollection = new ServiceCollection();
+        _ = serviceCollection.AddSingleton<IConnection>(mockConnection);
+        var serviceProvider = serviceCollection.BuildServiceProvider();
+
+        var healthCheck = new RabbitMQHealthCheck(serviceProvider, optionsMonitor);
+        var context = new HealthCheckContext
+        {
+            Registration = new HealthCheckRegistration(TestName, healthCheck, HealthStatus.Unhealthy, null),
+        };
+
+        // Act
+        _ = await healthCheck.CheckHealthAsync(context, CancellationToken.None);
+
+        // Assert
+        mockChannel.DisposeAsync().WasCalled(Times.Once);
+    }
+
+    [Test]
+    [SuppressMessage(
+        "Reliability",
+        "CA2025:Do not pass 'IDisposable' instances into unawaited tasks",
+        Justification = "As designed."
+    )]
+    public async Task CheckHealthAsync_WhenChannelNotOpen_ReturnsUnhealthyAndDisposesChannel()
+    {
+        // Arrange
+        var options = new RabbitMQOptions { KeyedService = null, Timeout = 1000 };
+
+        var optionsMonitor = IOptionsMonitor<RabbitMQOptions>.Mock();
+        _ = optionsMonitor.Get(TestName).Returns(options);
+
+        var mockChannel = IChannel.Mock();
+        _ = mockChannel.IsOpen.Returns(false);
+        var mockConnection = IConnection.Mock();
+        _ = mockConnection.CreateChannelAsync(Any(), Any()).Returns(mockChannel);
+
+        var serviceCollection = new ServiceCollection();
+        _ = serviceCollection.AddSingleton<IConnection>(mockConnection);
+        var serviceProvider = serviceCollection.BuildServiceProvider();
+
+        var healthCheck = new RabbitMQHealthCheck(serviceProvider, optionsMonitor);
+        var context = new HealthCheckContext
+        {
+            Registration = new HealthCheckRegistration(TestName, healthCheck, HealthStatus.Unhealthy, null),
+        };
+
+        // Act
+        var result = await healthCheck.CheckHealthAsync(context, CancellationToken.None);
+
+        // Assert
+        using (Assert.Multiple())
+        {
+            _ = await Assert.That(result.Status).IsEqualTo(HealthStatus.Unhealthy);
+            _ = await Assert
+                .That(result.Description)
+                .IsEqualTo($"{TestName}: Failed to create a channel to RabbitMQ.", StringComparison.Ordinal);
+        }
+        mockChannel.DisposeAsync().WasCalled(Times.Once);
+    }
+
+    [Test]
+    [SuppressMessage(
+        "Reliability",
+        "CA2025:Do not pass 'IDisposable' instances into unawaited tasks",
+        Justification = "As designed."
+    )]
     public async Task CheckHealthAsync_WhenTimeout_ReturnsDegraded()
     {
         // Arrange


### PR DESCRIPTION
## Problem

`RabbitMQHealthCheck.ExecuteHealthCheckAsync` calls `client.CreateChannelAsync(...)` and only inspects `channel.IsOpen` — the returned `IChannel` is never closed or disposed. Every health-check invocation opens a new AMQP channel on the shared `IConnection` and leaks it.

With the default ASP.NET Core health-check period (~30s), channels accumulate unboundedly on both client and broker. Once the negotiated `channel_max` (default 2047) is reached, `CreateChannelAsync` throws `ChannelAllocationException` and the check reports unhealthy even though the broker is fine, while broker memory grows per leaked channel.

## Fix

The `IsOpen` check and result-building logic are wrapped in `try`/`finally`; the `finally` block disposes the channel via `await channel.DisposeAsync().ConfigureAwait(false)`, covering all exit paths. (`await using` was avoided because `ConfiguredAsyncDisposable` is not null-safe in this pattern.)

## Tests

- New unit test `RabbitMQHealthCheckTests.CheckHealthAsync_WithoutKeyedService_DisposesChannel` — failed before the fix (`DisposeAsync` never called), passes after.
- RabbitMQ unit tests: 14/14 passed.
- Full unit test project (net9.0): 1862/1862 passed.