### PR TITLE
fix(Azure.EventHubs): dispose event hub clients synchronously

### DIFF
--- a/src/NetEvolve.HealthChecks.Azure.EventHubs/EventHubsClientFactory.cs
+++ b/src/NetEvolve.HealthChecks.Azure.EventHubs/EventHubsClientFactory.cs
@@ -4,6 +4,8 @@ using System;
 using System.Collections.Concurrent;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using System.Threading.Tasks;
 using global::Azure.Core;
 using global::Azure.Identity;
 using global::Azure.Messaging.EventHubs.Producer;
@@ -59,12 +61,22 @@ internal sealed class EventHubsClientFactory : IDisposable
         {
             if (disposing)
             {
-#pragma warning disable VSTHRD101 // Avoid unsupported async delegates
-                _ = Parallel.ForEach(
-                    _eventHubClients.Values,
-                    async client => await client.DisposeAsync().ConfigureAwait(false)
-                );
-#pragma warning restore VSTHRD101 // Avoid unsupported async delegates
+                try
+                {
+#pragma warning disable VSTHRD002 // Synchronously waiting on tasks or awaiters may cause deadlocks
+                    Task.WhenAll(_eventHubClients.Values.Select(client => client.DisposeAsync().AsTask()))
+                        .ConfigureAwait(false)
+                        .GetAwaiter()
+                        .GetResult();
+#pragma warning restore VSTHRD002 // Synchronously waiting on tasks or awaiters may cause deadlocks
+                }
+                catch
+                {
+                    // Disposal is best-effort. A faulting client (e.g. unreachable namespace
+                    // during shutdown) must not prevent the factory from completing disposal or
+                    // crash the process.
+                }
+
                 _eventHubClients.Clear();
             }
 

--- a/tests/NetEvolve.HealthChecks.Tests.Unit/Azure.EventHubs/EventHubsClientFactoryTests.cs
+++ b/tests/NetEvolve.HealthChecks.Tests.Unit/Azure.EventHubs/EventHubsClientFactoryTests.cs
@@ -1,7 +1,10 @@
 namespace NetEvolve.HealthChecks.Tests.Unit.Azure.EventHubs;
 
 using System;
+using System.Collections.Concurrent;
 using System.Diagnostics;
+using System.Reflection;
+using System.Threading.Tasks;
 using global::Azure.Messaging.EventHubs.Producer;
 using Microsoft.Extensions.DependencyInjection;
 using NetEvolve.Extensions.TUnit;
@@ -203,5 +206,83 @@ public sealed class EventHubsClientFactoryTests
 
         // Assert
         _ = Assert.Throws<InvalidOperationException>(Act);
+    }
+
+    [Test]
+    public async Task Dispose_WhenClientDisposalIsAsynchronous_ShouldCompleteBeforeReturning()
+    {
+        // Arrange
+        const string connectionString =
+            "Endpoint=sb://test.servicebus.windows.net/;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=testkey;EntityPath=eventhub1";
+        var clientFactory = new EventHubsClientFactory();
+        var delayedClient = new DelayedDisposeEventHubProducerClient(connectionString);
+
+        // Reach into the private client cache, since there is no public seam to inject a client
+        // whose DisposeAsync completes asynchronously.
+        var clientsField = typeof(EventHubsClientFactory).GetField(
+            "_eventHubClients",
+            BindingFlags.NonPublic | BindingFlags.Instance
+        );
+        var clients = (ConcurrentDictionary<string, EventHubProducerClient>)clientsField!.GetValue(clientFactory)!;
+        _ = clients.TryAdd(
+            nameof(Dispose_WhenClientDisposalIsAsynchronous_ShouldCompleteBeforeReturning),
+            delayedClient
+        );
+
+        // Act
+        ((IDisposable)clientFactory).Dispose();
+
+        // Assert
+        _ = await Assert.That(delayedClient.DisposeAsyncCompleted).IsTrue();
+    }
+
+    [Test]
+    public async Task Dispose_WhenClientDisposalThrows_ShouldNotThrow()
+    {
+        // Arrange
+        const string connectionString =
+            "Endpoint=sb://test.servicebus.windows.net/;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=testkey;EntityPath=eventhub1";
+        using var clientFactory = new EventHubsClientFactory();
+        var faultingClient = new FaultingDisposeEventHubProducerClient(connectionString);
+
+        var clientsField = typeof(EventHubsClientFactory).GetField(
+            "_eventHubClients",
+            BindingFlags.NonPublic | BindingFlags.Instance
+        );
+        var clients = (ConcurrentDictionary<string, EventHubProducerClient>)clientsField!.GetValue(clientFactory)!;
+        _ = clients.TryAdd(nameof(Dispose_WhenClientDisposalThrows_ShouldNotThrow), faultingClient);
+
+        // Act
+        void Act() => ((IDisposable)clientFactory).Dispose();
+
+        // Assert
+        _ = await Assert.That(Act).ThrowsNothing();
+    }
+
+    private sealed class DelayedDisposeEventHubProducerClient : EventHubProducerClient
+    {
+        public bool DisposeAsyncCompleted { get; private set; }
+
+        public DelayedDisposeEventHubProducerClient(string connectionString)
+            : base(connectionString) { }
+
+        public override async ValueTask DisposeAsync()
+        {
+            await Task.Delay(TimeSpan.FromMilliseconds(200)).ConfigureAwait(false);
+            await base.DisposeAsync().ConfigureAwait(false);
+            DisposeAsyncCompleted = true;
+        }
+    }
+
+    private sealed class FaultingDisposeEventHubProducerClient : EventHubProducerClient
+    {
+        public FaultingDisposeEventHubProducerClient(string connectionString)
+            : base(connectionString) { }
+
+        public override async ValueTask DisposeAsync()
+        {
+            await base.DisposeAsync().ConfigureAwait(false);
+            throw new InvalidOperationException("Simulated disposal failure.");
+        }
     }
 }


### PR DESCRIPTION
## Problem

`EventHubsClientFactory.Dispose(bool)` disposed cached `EventHubProducerClient` instances via `Parallel.ForEach(_eventHubClients.Values, async client => await client.DisposeAsync()...)`. Since `Parallel.ForEach` takes `Action<T>`, the lambda compiles to an async void delegate:

- The loop returns as soon as each client's `DisposeAsync` hits its first `await` — `_eventHubClients.Clear()` runs while disposals are still in flight, so `Dispose()` returns before disposal actually completes.
- Any exception thrown by `DisposeAsync` (e.g., AMQP link tear-down failure during app shutdown while the namespace is unreachable) surfaces as an unhandled exception on the thread pool and can crash the process instead of allowing a clean shutdown.

The suppressed `VSTHRD101` warning flagged exactly this.

## Fix

Collect the `DisposeAsync` tasks and wait on them with `Task.WhenAll(...).ConfigureAwait(false).GetAwaiter().GetResult()` before clearing the cache, wrapped in `try`/`catch` so a faulting client's `DisposeAsync` cannot escape as an unobserved exception. The intentional sync wait is annotated with `VSTHRD002` suppression, mirroring the existing suppression style in the file.

## Tests

- New fail-first test `Dispose_WhenClientDisposalIsAsynchronous_ShouldCompleteBeforeReturning` — failed before the fix (`Dispose()` returned before async disposal completed), passes after.
- New regression guard `Dispose_WhenClientDisposalThrows_ShouldNotThrow`.
- EventHubsClientFactoryTests: 10/10 passed; all EventHubs unit tests: 38/38 passed.
- Full unit test project (net9.0): 1863/1863 passed. Touched project builds with 0 warnings.