### PR TITLE
fix(sourcegen): allow opt-in for health checks whose default options are valid

### DIFF
--- a/src/NetEvolve.HealthChecks.Dapr/DaprHealthCheck.cs
+++ b/src/NetEvolve.HealthChecks.Dapr/DaprHealthCheck.cs
@@ -8,7 +8,7 @@ using Microsoft.Extensions.Diagnostics.HealthChecks;
 using NetEvolve.Extensions.Tasks;
 using SourceGenerator.Attributes;
 
-[ConfigurableHealthCheck(typeof(DaprOptions))]
+[ConfigurableHealthCheck(typeof(DaprOptions), acceptDefaultConfiguration: true)]
 internal sealed partial class DaprHealthCheck
 {
     private async ValueTask<HealthCheckResult> ExecuteHealthCheckAsync(

--- a/src/SourceGenerator.Attributes/ConfigurableHealthCheckAttribute.cs
+++ b/src/SourceGenerator.Attributes/ConfigurableHealthCheckAttribute.cs
@@ -16,8 +16,18 @@ using System.Diagnostics.CodeAnalysis;
 /// <param name="includeWin32Handling">
 /// Indicates whether to include Win32 error code handling in the generated health check code.
 /// </param>
+/// <param name="acceptDefaultConfiguration">
+/// Indicates whether an options instance equal to a default-constructed <paramref name="optionsType"/> is considered valid configuration.
+/// Set this to <see langword="true"/> for health checks whose defaults are fully functional, e.g. because the client is resolved from DI
+/// instead of being built from the options. When <see langword="false"/> (default), the generated health check reports
+/// "Missing configuration." whenever the resolved options equal the type's default value.
+/// </param>
 [AttributeUsage(AttributeTargets.Class, AllowMultiple = false, Inherited = false)]
 [ExcludeFromCodeCoverage]
 #pragma warning disable CS9113, CA1019 // Parameter is unread.
-public sealed class ConfigurableHealthCheckAttribute(Type optionsType, bool includeWin32Handling = false) : Attribute;
+public sealed class ConfigurableHealthCheckAttribute(
+    Type optionsType,
+    bool includeWin32Handling = false,
+    bool acceptDefaultConfiguration = false
+) : Attribute;
 #pragma warning restore CS9113, CA1019 // Parameter is unread.

--- a/src/SourceGenerator.HealthChecks/CodeGenerator.cs
+++ b/src/SourceGenerator.HealthChecks/CodeGenerator.cs
@@ -8,7 +8,8 @@ internal static class CodeGenerator
         ICandidate candidate,
         Action<CSharpCodeBuilder>? additionalCode = null,
         bool withWin32ExceptionHandling = false,
-        bool includeServiceProvider = false
+        bool includeServiceProvider = false,
+        bool acceptDefaultConfiguration = false
     )
     {
         var cb = new CSharpCodeBuilder(500)
@@ -78,9 +79,12 @@ internal static class CodeGenerator
                 {
                     _ = cb.AppendLine("var options = _optionsMonitor.Get(name);");
 
-                    using (cb.ScopeLine("if (options?.Equals(_defaultConfiguration) != false)"))
+                    if (!acceptDefaultConfiguration)
                     {
-                        _ = cb.HealthCheckUnhealthy("Missing configuration.");
+                        using (cb.ScopeLine("if (options?.Equals(_defaultConfiguration) != false)"))
+                        {
+                            _ = cb.HealthCheckUnhealthy("Missing configuration.");
+                        }
                     }
 
                     _ = cb.AppendLine()

--- a/src/SourceGenerator.HealthChecks/Generators/ConfigurableHealthCheckGenerator.cs
+++ b/src/SourceGenerator.HealthChecks/Generators/ConfigurableHealthCheckGenerator.cs
@@ -28,7 +28,8 @@ internal sealed class ConfigurableHealthCheckGenerator : IIncrementalGenerator
             candidate,
             GenerateHelperMethods,
             withWin32ExceptionHandling: candidate.IncludeWin32Handling,
-            includeServiceProvider: true
+            includeServiceProvider: true,
+            acceptDefaultConfiguration: candidate.AcceptDefaultConfiguration
         );
         context.AddSource($"{candidate.Name}.g.cs", SourceText.From(codeBuilder.ToString(), Encoding.UTF8));
     }
@@ -81,7 +82,7 @@ internal sealed class ConfigurableHealthCheckGenerator : IIncrementalGenerator
         AttributeData attributeData
     )
     {
-        if (attributeData.ConstructorArguments.Length != 2)
+        if (attributeData.ConstructorArguments.Length != 3)
         {
             return null;
         }
@@ -103,6 +104,7 @@ internal sealed class ConfigurableHealthCheckGenerator : IIncrementalGenerator
             OptionsTypeName = optionsType.Name,
             OptionsTypeNamespace = optionsType.ContainingNamespace.ToDisplayString(),
             IncludeWin32Handling = attributeData.ConstructorArguments[1].Value is true,
+            AcceptDefaultConfiguration = attributeData.ConstructorArguments[2].Value is true,
         };
     }
 
@@ -118,5 +120,7 @@ internal sealed class ConfigurableHealthCheckGenerator : IIncrementalGenerator
         public string OptionsTypeNamespace { get; internal set; } = default!;
 
         public bool IncludeWin32Handling { get; set; }
+
+        public bool AcceptDefaultConfiguration { get; set; }
     }
 }

--- a/tests/NetEvolve.HealthChecks.Tests.Unit/Dapr/DaprHealthCheckTests.cs
+++ b/tests/NetEvolve.HealthChecks.Tests.Unit/Dapr/DaprHealthCheckTests.cs
@@ -49,6 +49,37 @@ public sealed class DaprHealthCheckTests
     }
 
     [Test]
+    public async Task CheckHealthAsync_WithDefaultOptions_ReturnsHealthy()
+    {
+        // Arrange
+        var options = new DaprOptions(); // Fully valid: DaprClient is resolved from DI, no configuration is required.
+
+        var optionsMonitor = IOptionsMonitor<DaprOptions>.Mock();
+        _ = optionsMonitor.Get(TestName).Returns(options);
+
+        var mockClient = DaprClient.Mock();
+        _ = mockClient.CheckHealthAsync(Any()).Returns(true);
+
+        var serviceProvider = new ServiceCollection().AddSingleton<DaprClient>(mockClient).BuildServiceProvider();
+
+        var healthCheck = new DaprHealthCheck(serviceProvider, optionsMonitor);
+        var context = new HealthCheckContext
+        {
+            Registration = new HealthCheckRegistration(TestName, healthCheck, HealthStatus.Unhealthy, null),
+        };
+
+        // Act
+        var result = await healthCheck.CheckHealthAsync(context, CancellationToken.None);
+
+        // Assert
+        using (Assert.Multiple())
+        {
+            _ = await Assert.That(result.Status).IsEqualTo(HealthStatus.Healthy);
+            _ = await Assert.That(result.Description).IsEqualTo($"{TestName}: Healthy");
+        }
+    }
+
+    [Test]
     public async Task CheckHealthAsync_WhenDaprUnhealthy_ReturnsDegraded()
     {
         // Arrange


### PR DESCRIPTION
## Problem

The source generator emits `if (options?.Equals(_defaultConfiguration) != false)` → Unhealthy "Missing configuration." in every generated `CheckHealthAsync`. All options types are records, so this is value equality against all-default options.

For packages whose defaults are fully valid because the client comes from DI (e.g., Dapr), a user calling `AddDapr()` with no options delegate and no `HealthChecks:DaprSidecar` config section gets options equal to `new DaprOptions()` — and the check permanently reports Unhealthy "Missing configuration." even though the Dapr sidecar is healthy. Existing tests masked this by always setting `Timeout` explicitly.

## Fix

- `ConfigurableHealthCheckAttribute` gains an optional third constructor parameter `acceptDefaultConfiguration = false`.
- `ConfigurableHealthCheckGenerator` reads the flag and threads it into `CodeGenerator.ConfigurableHealthCheck`, which only emits the default-equality guard when the flag is `false` — generated output is unchanged for every package that does not opt in.
- `DaprHealthCheck` opts in via `[ConfigurableHealthCheck(typeof(DaprOptions), acceptDefaultConfiguration: true)]`.

Other DI-client packages (Kubernetes, MongoDb, NATS, Mosquitto, InfluxDB, Cassandra, Couchbase, Neo4j, RavenDb, KurrentDb, ...) are likely candidates as well, but each needs its own confirmation that all-default options are valid before opting in — intentionally left for follow-up.

## Tests

- New unit test `CheckHealthAsync_WithDefaultOptions_ReturnsHealthy` (Dapr, bare `new DaprOptions()` with healthy mocked `DaprClient`) — failed before the fix with "Dapr: Missing configuration.", passes after.
- Dapr unit tests: 8/8 passed.
- Full unit test project (net9.0): 1862/1862 passed.