### PR TITLE
fix(sourcegenerator): correct infinite timeout handling in sync SQL health checks

### DIFF
--- a/src/SourceGenerator.HealthChecks/Generators/SqlHealthCheckGenerator.cs
+++ b/src/SourceGenerator.HealthChecks/Generators/SqlHealthCheckGenerator.cs
@@ -94,7 +94,9 @@ internal sealed class SqlHealthCheckGenerator : IIncrementalGenerator
                     .AppendLine("#pragma warning restore CA2100 // Review SQL queries for security vulnerabilities")
                     .AppendLine("var sw = Stopwatch.StartNew();")
                     .AppendLine("_ = command.ExecuteNonQuery();")
-                    .AppendLine("var isTimelyResponse = options.Timeout >= sw.Elapsed.TotalMilliseconds;")
+                    .AppendLine(
+                        "var isTimelyResponse = options.Timeout == global::System.Threading.Timeout.Infinite || options.Timeout >= sw.Elapsed.TotalMilliseconds;"
+                    )
                     .HealthCheckStateValueTask("isTimelyResponse");
             }
         }

--- a/tests/NetEvolve.HealthChecks.Tests.Integration/SqlServer.Legacy/SqlServerLegacyHealthCheckTests.cs
+++ b/tests/NetEvolve.HealthChecks.Tests.Integration/SqlServer.Legacy/SqlServerLegacyHealthCheckTests.cs
@@ -36,6 +36,23 @@ public class SqlServerLegacyHealthCheckTests : HealthCheckTestBase
         );
 
     [Test]
+    public async Task AddSqlServerLegacy_UseOptions_InfiniteTimeout_Healthy() =>
+        await RunAndVerify(
+            healthChecks =>
+            {
+                _ = healthChecks.AddSqlServerLegacy(
+                    "TestContainerHealthyInfiniteTimeout",
+                    options =>
+                    {
+                        options.ConnectionString = _database.ConnectionString;
+                        options.Timeout = Timeout.Infinite;
+                    }
+                );
+            },
+            HealthStatus.Healthy
+        );
+
+    [Test]
     public async Task AddSqlServerLegacy_UseOptions_Degraded() =>
         await RunAndVerify(
             healthChecks =>

--- a/tests/NetEvolve.HealthChecks.Tests.Integration/_snapshots/SqlServerLegacyHealthCheck.AddSqlServerLegacy_UseOptions_InfiniteTimeout_Healthy.verified.txt
+++ b/tests/NetEvolve.HealthChecks.Tests.Integration/_snapshots/SqlServerLegacyHealthCheck.AddSqlServerLegacy_UseOptions_InfiniteTimeout_Healthy.verified.txt
@@ -1,0 +1,15 @@
+{
+  results: [
+    {
+      description: TestContainerHealthyInfiniteTimeout: Healthy,
+      name: TestContainerHealthyInfiniteTimeout,
+      status: Healthy,
+      tags: [
+        sqlserver,
+        database,
+        legacy
+      ]
+    }
+  ],
+  status: Healthy
+}


### PR DESCRIPTION
## Problem

The synchronous code path in `SqlHealthCheckGenerator` emits:

```csharp
var isTimelyResponse = options.Timeout >= sw.Elapsed.TotalMilliseconds;
```

Every options validator explicitly allows `Timeout = -1` ("or -1 for an infinite timeout"), and the async path treats `-1` as always timely (`WithTimeoutAsync` returns `isValid = true` for `Timeout.Infinite`). In the sync path, however, `-1 >= elapsed` is always false — so DB2, SqlServer.Legacy, SqlServer.Devart, Oracle.Devart, Npgsql.Devart, and MySql.Devart health checks configured with `Timeout = -1` report Degraded on every successful query.

## Fix

The generated expression now short-circuits on infinite timeout, matching async semantics:

```csharp
var isTimelyResponse = options.Timeout == global::System.Threading.Timeout.Infinite || options.Timeout >= sw.Elapsed.TotalMilliseconds;
```

`Timeout = 0` behavior is unchanged (still Degraded, per existing tests).

## Tests

- New integration test `AddSqlServerLegacy_UseOptions_InfiniteTimeout_Healthy` (Testcontainers-backed SQL Server, `Timeout = -1`) — reported Degraded before the fix, Healthy after.
- Full SqlServer.Legacy integration group (8 tests, including the pre-existing `Timeout = 0` → Degraded case): passed.
- Full unit test suite (net9.0): 1861/1861 passed. Generator change compiles cleanly for all affected sync SQL packages.