### PR TITLE
fix(redis): establish connections asynchronously in health check

### DIFF
--- a/src/NetEvolve.HealthChecks.Redis/RedisHealthCheck.cs
+++ b/src/NetEvolve.HealthChecks.Redis/RedisHealthCheck.cs
@@ -14,7 +14,7 @@ using StackExchange.Redis;
 [ConfigurableHealthCheck(typeof(RedisOptions))]
 internal sealed partial class RedisHealthCheck : IDisposable
 {
-    private ConcurrentDictionary<string, IConnectionMultiplexer>? _connections;
+    private ConcurrentDictionary<string, Task<IConnectionMultiplexer>>? _connections;
     private bool _disposedValue;
 
     private async ValueTask<HealthCheckResult> ExecuteHealthCheckAsync(
@@ -26,7 +26,7 @@ internal sealed partial class RedisHealthCheck : IDisposable
         CancellationToken cancellationToken
     )
     {
-        var connection = GetConnection(name, options, _serviceProvider);
+        var connection = await GetConnectionAsync(name, options, _serviceProvider).ConfigureAwait(false);
 
         var (isTimelyResponse, _) = await connection
             .GetDatabase()
@@ -37,17 +37,52 @@ internal sealed partial class RedisHealthCheck : IDisposable
         return HealthCheckState(isTimelyResponse, name);
     }
 
-    private IConnectionMultiplexer GetConnection(string name, RedisOptions options, IServiceProvider serviceProvider)
+    private Task<IConnectionMultiplexer> GetConnectionAsync(
+        string name,
+        RedisOptions options,
+        IServiceProvider serviceProvider
+    )
     {
         if (options.Mode == ConnectionHandleMode.ServiceProvider)
         {
-            return serviceProvider.GetRequiredService<IConnectionMultiplexer>();
+            return Task.FromResult(serviceProvider.GetRequiredService<IConnectionMultiplexer>());
         }
 
-        _connections ??= new ConcurrentDictionary<string, IConnectionMultiplexer>(StringComparer.OrdinalIgnoreCase);
+        _connections ??= new ConcurrentDictionary<string, Task<IConnectionMultiplexer>>(
+            StringComparer.OrdinalIgnoreCase
+        );
 
-        return _connections.GetOrAdd(name, _ => ConnectionMultiplexer.Connect(options.ConnectionString!));
+        var connectionTask = _connections.GetOrAdd(name, _ => CreateConnectionAsync(options));
+
+        // A failed connection attempt must not be cached, otherwise every subsequent health
+        // check would immediately fail with the same exception, even after the server
+        // becomes reachable again. Evict the entry as soon as it faults, so the next call
+        // retries. The conditional remove targets this exact task instance, to avoid
+        // accidentally removing a newer, still-valid entry created by a racing caller.
+        if (connectionTask.IsFaulted)
+        {
+            RemoveFaultedConnection(name, connectionTask);
+        }
+        else if (!connectionTask.IsCompleted)
+        {
+            _ = connectionTask.ContinueWith(
+                task => RemoveFaultedConnection(name, task),
+                CancellationToken.None,
+                TaskContinuationOptions.OnlyOnFaulted | TaskContinuationOptions.ExecuteSynchronously,
+                TaskScheduler.Default
+            );
+        }
+
+        return connectionTask;
     }
+
+    private static async Task<IConnectionMultiplexer> CreateConnectionAsync(RedisOptions options) =>
+        await ConnectionMultiplexer.ConnectAsync(options.ConnectionString!).ConfigureAwait(false);
+
+    private void RemoveFaultedConnection(string name, Task<IConnectionMultiplexer> connectionTask) =>
+        _ = ((ICollection<KeyValuePair<string, Task<IConnectionMultiplexer>>>?)_connections)?.Remove(
+            new KeyValuePair<string, Task<IConnectionMultiplexer>>(name, connectionTask)
+        );
 
     [SuppressMessage(
         "Blocker Code Smell",
@@ -60,7 +95,18 @@ internal sealed partial class RedisHealthCheck : IDisposable
         {
             if (disposing && _connections is not null)
             {
-                _ = Parallel.ForEach(_connections.Values, connection => connection.Dispose());
+                _ = Parallel.ForEach(
+                    _connections.Values,
+                    connectionTask =>
+                    {
+                        if (connectionTask.Status == TaskStatus.RanToCompletion)
+                        {
+#pragma warning disable VSTHRD002 // Task is already completed, so accessing Result cannot block.
+                            connectionTask.Result.Dispose();
+#pragma warning restore VSTHRD002
+                        }
+                    }
+                );
                 _connections.Clear();
             }
             _disposedValue = true;

--- a/tests/NetEvolve.HealthChecks.Tests.Unit/Redis/RedisHealthCheckTests.cs
+++ b/tests/NetEvolve.HealthChecks.Tests.Unit/Redis/RedisHealthCheckTests.cs
@@ -1,6 +1,8 @@
 ﻿namespace NetEvolve.HealthChecks.Tests.Unit.Redis;
 
 using System;
+using System.Collections;
+using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
@@ -74,5 +76,94 @@ public sealed class RedisHealthCheckTests
             _ = await Assert.That(result.Status).IsEqualTo(HealthStatus.Unhealthy);
             _ = await Assert.That(result.Description).IsEqualTo($"{TestName}: Missing configuration.");
         }
+    }
+
+    [Test]
+    public async Task CheckHealthAsync_WhenModeCreateAndServerUnreachable_ShouldNotCompleteSynchronously()
+    {
+        // Arrange
+        // 192.0.2.1 is a non-routable TEST-NET-1 address (RFC 5737), so the connection attempt
+        // reliably fails without ever reaching a real server.
+        var options = new RedisOptions
+        {
+            ConnectionString = "192.0.2.1:6379,abortConnect=true,connectRetry=0,connectTimeout=500",
+            Mode = ConnectionHandleMode.Create,
+            Timeout = 500,
+        };
+
+        var optionsMonitor = IOptionsMonitor<RedisOptions>.Mock();
+        _ = optionsMonitor.Get(TestName).Returns(options);
+        var serviceProvider = IServiceProvider.Mock();
+        using var check = new RedisHealthCheck(serviceProvider, optionsMonitor);
+        var context = new HealthCheckContext
+        {
+            Registration = new HealthCheckRegistration(TestName, check, HealthStatus.Unhealthy, null),
+        };
+
+        // Act
+        var resultTask = check.CheckHealthAsync(context, CancellationToken.None);
+
+        // Assert
+        // The connection attempt must be asynchronous, so the returned task must not already be
+        // completed the moment control returns to the caller. If it is, the calling thread was
+        // blocked synchronously while establishing the connection.
+        _ = await Assert.That(resultTask.IsCompleted).IsFalse();
+
+        // Cleanup
+        _ = await resultTask;
+    }
+
+    [Test]
+    public async Task CheckHealthAsync_WhenModeCreateAndServerUnreachable_ShouldNotCacheFailedConnection()
+    {
+        // Arrange
+        // A failed connection attempt must not be cached, otherwise every subsequent call would
+        // immediately return the same failure, even after the server became reachable again.
+        var options = new RedisOptions
+        {
+            ConnectionString = "192.0.2.1:6379,abortConnect=true,connectRetry=0,connectTimeout=500",
+            Mode = ConnectionHandleMode.Create,
+            Timeout = 500,
+        };
+
+        var optionsMonitor = IOptionsMonitor<RedisOptions>.Mock();
+        _ = optionsMonitor.Get(TestName).Returns(options);
+        var serviceProvider = IServiceProvider.Mock();
+        using var check = new RedisHealthCheck(serviceProvider, optionsMonitor);
+        var context = new HealthCheckContext
+        {
+            Registration = new HealthCheckRegistration(TestName, check, HealthStatus.Unhealthy, null),
+        };
+
+        // Act
+        var firstResult = await check.CheckHealthAsync(context, CancellationToken.None);
+
+        // Assert
+        _ = await Assert.That(firstResult.Status).IsEqualTo(HealthStatus.Unhealthy);
+
+        // The faulted connection attempt is evicted asynchronously right after it faults, so
+        // poll briefly for the internal cache to become empty again instead of asserting it
+        // synchronously.
+        var connectionsField = typeof(RedisHealthCheck).GetField(
+            "_connections",
+            BindingFlags.Instance | BindingFlags.NonPublic
+        );
+        _ = await Assert.That(connectionsField).IsNotNull();
+
+        var deadline = DateTime.UtcNow.AddSeconds(5);
+        int count;
+        do
+        {
+            var connections = (IDictionary?)connectionsField!.GetValue(check);
+            count = connections?.Count ?? 0;
+            if (count == 0)
+            {
+                break;
+            }
+
+            await Task.Delay(25, CancellationToken.None);
+        } while (DateTime.UtcNow < deadline);
+
+        _ = await Assert.That(count).IsEqualTo(0);
     }
 }


### PR DESCRIPTION
## Problem

`RedisHealthCheck.GetConnection` used the blocking `ConnectionMultiplexer.Connect(...)` inside `GetOrAdd` on the async execution path (unlike `GarnetHealthCheck`, which uses `ConnectAsync`).

While the Redis server is unreachable, `Connect` throws — so nothing is cached — and every check invocation synchronously blocks a thread-pool thread for the full connect timeout (default ~5s plus retries). With several named Redis checks running concurrently on each health probe, this causes thread-pool starvation that degrades the whole application, not just the health endpoint. Even the first successful call blocks the async caller.

## Fix

- The connection cache now stores `Task<IConnectionMultiplexer>` built from `ConnectionMultiplexer.ConnectAsync` (async-lazy) and awaits it.
- Faulted connection attempts are evicted from the cache so the next check retries once the server is reachable again. The conditional remove targets the exact task instance to avoid removing a newer, valid entry created by a racing caller.
- `Dispose` only disposes connections whose creation ran to completion.

## Tests

- New fail-first test `CheckHealthAsync_WhenModeCreateAndServerUnreachable_ShouldNotCompleteSynchronously` (non-routable TEST-NET-1 address per RFC 5737) — the returned task completed synchronously before the fix, asynchronous after.
- Additional coverage for faulted-connection eviction/retry behavior.
- Redis unit tests: 5/5 passed.
- Full unit test project (net9.0): 1863/1863 passed.