### PR TITLE
chore(tests): replace NSubstitute with TUnit.Mocks

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -100,8 +100,6 @@
     <PackageVersion Include="NetEvolve.Extensions.TUnit" Version="3.5.348" />
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.4" />
     <PackageVersion Include="Npgsql" Version="10.0.3" />
-    <PackageVersion Include="NSubstitute" Version="6.0.0" />
-    <PackageVersion Include="NSubstitute.Analyzers.CSharp" Version="1.0.17" />
     <PackageVersion Include="OllamaSharp" Version="5.4.30" />
     <PackageVersion Include="OpenSearch.Client" Version="2.0.0" />
     <PackageVersion Include="OpenTelemetry.Api" Version="1.17.0" />
@@ -171,8 +169,8 @@
     <PackageVersion Include="Testcontainers.Redpanda" Version="4.13.0" />
     <PackageVersion Include="Testcontainers.ServiceBus" Version="4.13.0" />
     <PackageVersion Include="TngTech.ArchUnitNET.TUnit" Version="0.13.3" />
-    <PackageVersion Include="TUnit" Version="1.61.38" />
-    <PackageVersion Include="TUnit.Mocks" Version="1.61.38" />
+    <PackageVersion Include="TUnit" Version="1.62.0" />
+    <PackageVersion Include="TUnit.Mocks" Version="1.62.0" />
     <PackageVersion Include="Verify.TUnit" Version="31.27.0" />
   </ItemGroup>
 </Project>

--- a/tests/NetEvolve.HealthChecks.Tests.Unit/Azure.ServiceBus/ServiceBusQueueAdministrationTests.cs
+++ b/tests/NetEvolve.HealthChecks.Tests.Unit/Azure.ServiceBus/ServiceBusQueueAdministrationTests.cs
@@ -1,8 +1,6 @@
-﻿namespace NetEvolve.HealthChecks.Tests.Unit.Azure.ServiceBus;
+namespace NetEvolve.HealthChecks.Tests.Unit.Azure.ServiceBus;
 
 using System;
-using System.Diagnostics.CodeAnalysis;
-using System.Threading;
 using System.Threading.Tasks;
 using global::Azure.Messaging.ServiceBus.Administration;
 using Microsoft.Extensions.DependencyInjection;
@@ -10,7 +8,7 @@ using Microsoft.Extensions.Diagnostics.HealthChecks;
 using Microsoft.Extensions.Options;
 using NetEvolve.Extensions.TUnit;
 using NetEvolve.HealthChecks.Azure.ServiceBus;
-using NSubstitute;
+using TUnit.Mocks;
 
 [TestGroup($"{nameof(Azure)}.{nameof(ServiceBus)}")]
 [TestGroup($"{nameof(Azure)}.{nameof(ServiceBus)}.Queue")]
@@ -29,10 +27,10 @@ public sealed class ServiceBusQueueAdministrationTests
             EnablePeekMode = false,
         };
 
-        var optionsMonitor = Substitute.For<IOptionsMonitor<ServiceBusQueueOptions>>();
+        var optionsMonitor = IOptionsMonitor<ServiceBusQueueOptions>.Mock();
         _ = optionsMonitor.Get("test").Returns(options);
 
-        var serviceProvider = Substitute.For<IServiceProvider>();
+        var serviceProvider = IServiceProvider.Mock();
         var healthCheck = new ServiceBusQueueHealthCheck(serviceProvider, optionsMonitor);
 
         var context = new HealthCheckContext
@@ -58,11 +56,11 @@ public sealed class ServiceBusQueueAdministrationTests
             EnablePeekMode = false,
         };
 
-        var optionsMonitor = Substitute.For<IOptionsMonitor<ServiceBusQueueOptions>>();
+        var optionsMonitor = IOptionsMonitor<ServiceBusQueueOptions>.Mock();
         _ = optionsMonitor.Get("test").Returns(options);
 
         // Create a mock service provider with a mock administration client
-        var mockAdminClient = Substitute.For<ServiceBusAdministrationClient>();
+        var mockAdminClient = ServiceBusAdministrationClient.Mock();
         var serviceCollection = new ServiceCollection();
         _ = serviceCollection.AddSingleton(mockAdminClient);
         var serviceProvider = serviceCollection.BuildServiceProvider();
@@ -76,14 +74,13 @@ public sealed class ServiceBusQueueAdministrationTests
 
         // Setup mock to throw exception to simulate queue not existing
         _ = mockAdminClient
-            .GetQueueRuntimePropertiesAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
-            .Returns<global::Azure.Response<QueueRuntimeProperties>>(_ =>
-            {
-                throw new global::Azure.Messaging.ServiceBus.ServiceBusException(
+            .GetQueueRuntimePropertiesAsync(Any(), Any())
+            .Throws(
+                new global::Azure.Messaging.ServiceBus.ServiceBusException(
                     "Queue not found",
                     global::Azure.Messaging.ServiceBus.ServiceBusFailureReason.MessagingEntityNotFound
-                );
-            });
+                )
+            );
 
         // Act
         var result = await healthCheck.CheckHealthAsync(context);
@@ -93,11 +90,6 @@ public sealed class ServiceBusQueueAdministrationTests
     }
 
     [Test]
-    [SuppressMessage(
-        "Substitute creation",
-        "NS2001:Could not find accessible constructor.",
-        Justification = "Reviewed"
-    )]
     public async Task CheckHealthAsync_WhenTimeout_ShouldReturnUnhealthy()
     {
         // Arrange
@@ -109,11 +101,11 @@ public sealed class ServiceBusQueueAdministrationTests
             Timeout = 1, // Very short timeout to force failure
         };
 
-        var optionsMonitor = Substitute.For<IOptionsMonitor<ServiceBusQueueOptions>>();
+        var optionsMonitor = IOptionsMonitor<ServiceBusQueueOptions>.Mock();
         _ = optionsMonitor.Get("test").Returns(options);
 
         // Create a mock service provider with a mock administration client
-        var mockAdminClient = Substitute.For<ServiceBusAdministrationClient>();
+        var mockAdminClient = ServiceBusAdministrationClient.Mock();
         var serviceCollection = new ServiceCollection();
         _ = serviceCollection.AddSingleton(mockAdminClient);
         var serviceProvider = serviceCollection.BuildServiceProvider();
@@ -127,13 +119,13 @@ public sealed class ServiceBusQueueAdministrationTests
 
         // Setup mock to delay longer than the timeout
         _ = mockAdminClient
-            .GetQueueRuntimePropertiesAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
-            .Returns(async _ =>
+            .GetQueueRuntimePropertiesAsync(Any(), Any())
+            .ReturnsAsync(async () =>
             {
                 await Task.Delay(100); // Delay longer than the timeout
                 return global::Azure.Response.FromValue(
-                    Substitute.For<QueueRuntimeProperties>(),
-                    Substitute.For<global::Azure.Response>()
+                    global::Azure.Messaging.ServiceBus.ServiceBusModelFactory.QueueRuntimeProperties("timeout-queue"),
+                    global::Azure.Response.Mock()
                 );
             });
 

--- a/tests/NetEvolve.HealthChecks.Tests.Unit/Azure.ServiceBus/ServiceBusSubscriptionAdministrationTests.cs
+++ b/tests/NetEvolve.HealthChecks.Tests.Unit/Azure.ServiceBus/ServiceBusSubscriptionAdministrationTests.cs
@@ -1,7 +1,6 @@
-﻿namespace NetEvolve.HealthChecks.Tests.Unit.Azure.ServiceBus;
+namespace NetEvolve.HealthChecks.Tests.Unit.Azure.ServiceBus;
 
 using System;
-using System.Diagnostics.CodeAnalysis;
 using System.Threading;
 using System.Threading.Tasks;
 using global::Azure.Messaging.ServiceBus.Administration;
@@ -10,7 +9,7 @@ using Microsoft.Extensions.Diagnostics.HealthChecks;
 using Microsoft.Extensions.Options;
 using NetEvolve.Extensions.TUnit;
 using NetEvolve.HealthChecks.Azure.ServiceBus;
-using NSubstitute;
+using TUnit.Mocks;
 
 [TestGroup($"{nameof(Azure)}.{nameof(ServiceBus)}")]
 [TestGroup($"{nameof(Azure)}.{nameof(ServiceBus)}.Subscription")]
@@ -30,10 +29,10 @@ public sealed class ServiceBusSubscriptionAdministrationTests
             EnablePeekMode = false,
         };
 
-        var optionsMonitor = Substitute.For<IOptionsMonitor<ServiceBusSubscriptionOptions>>();
+        var optionsMonitor = IOptionsMonitor<ServiceBusSubscriptionOptions>.Mock();
         _ = optionsMonitor.Get("test").Returns(options);
 
-        var serviceProvider = Substitute.For<IServiceProvider>();
+        var serviceProvider = IServiceProvider.Mock();
         var healthCheck = new ServiceBusSubscriptionHealthCheck(serviceProvider, optionsMonitor);
 
         var context = new HealthCheckContext
@@ -60,11 +59,11 @@ public sealed class ServiceBusSubscriptionAdministrationTests
             EnablePeekMode = false,
         };
 
-        var optionsMonitor = Substitute.For<IOptionsMonitor<ServiceBusSubscriptionOptions>>();
+        var optionsMonitor = IOptionsMonitor<ServiceBusSubscriptionOptions>.Mock();
         _ = optionsMonitor.Get("test").Returns(options);
 
         // Create a mock service provider with a mock administration client
-        var mockAdminClient = Substitute.For<ServiceBusAdministrationClient>();
+        var mockAdminClient = ServiceBusAdministrationClient.Mock();
         var serviceCollection = new ServiceCollection();
         _ = serviceCollection.AddSingleton(mockAdminClient);
         var serviceProvider = serviceCollection.BuildServiceProvider();
@@ -78,14 +77,13 @@ public sealed class ServiceBusSubscriptionAdministrationTests
 
         // Setup mock to throw exception to simulate subscription not existing
         _ = mockAdminClient
-            .GetSubscriptionRuntimePropertiesAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
-            .Returns<global::Azure.Response<SubscriptionRuntimeProperties>>(_ =>
-            {
-                throw new global::Azure.Messaging.ServiceBus.ServiceBusException(
+            .GetSubscriptionRuntimePropertiesAsync(Any<string>(), Any<string>(), Any<CancellationToken>())
+            .Throws(
+                new global::Azure.Messaging.ServiceBus.ServiceBusException(
                     "Subscription not found",
                     global::Azure.Messaging.ServiceBus.ServiceBusFailureReason.MessagingEntityNotFound
-                );
-            });
+                )
+            );
 
         // Act
         var result = await healthCheck.CheckHealthAsync(context);
@@ -95,11 +93,6 @@ public sealed class ServiceBusSubscriptionAdministrationTests
     }
 
     [Test]
-    [SuppressMessage(
-        "Substitute creation",
-        "NS2001:Could not find accessible constructor.",
-        Justification = "Reviewed"
-    )]
     public async Task CheckHealthAsync_WhenTimeout_ShouldReturnUnhealthy()
     {
         // Arrange
@@ -112,11 +105,11 @@ public sealed class ServiceBusSubscriptionAdministrationTests
             Timeout = 1, // Very short timeout to force failure
         };
 
-        var optionsMonitor = Substitute.For<IOptionsMonitor<ServiceBusSubscriptionOptions>>();
+        var optionsMonitor = IOptionsMonitor<ServiceBusSubscriptionOptions>.Mock();
         _ = optionsMonitor.Get("test").Returns(options);
 
         // Create a mock service provider with a mock administration client
-        var mockAdminClient = Substitute.For<ServiceBusAdministrationClient>();
+        var mockAdminClient = ServiceBusAdministrationClient.Mock();
         var serviceCollection = new ServiceCollection();
         _ = serviceCollection.AddSingleton(mockAdminClient);
         var serviceProvider = serviceCollection.BuildServiceProvider();
@@ -130,13 +123,16 @@ public sealed class ServiceBusSubscriptionAdministrationTests
 
         // Setup mock to delay longer than the timeout
         _ = mockAdminClient
-            .GetSubscriptionRuntimePropertiesAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
-            .Returns(async _ =>
+            .GetSubscriptionRuntimePropertiesAsync(Any<string>(), Any<string>(), Any<CancellationToken>())
+            .ReturnsAsync(async () =>
             {
                 await Task.Delay(100); // Delay longer than the timeout
                 return global::Azure.Response.FromValue(
-                    Substitute.For<SubscriptionRuntimeProperties>(),
-                    Substitute.For<global::Azure.Response>()
+                    global::Azure.Messaging.ServiceBus.ServiceBusModelFactory.SubscriptionRuntimeProperties(
+                        "timeout-topic",
+                        "timeout-subscription"
+                    ),
+                    global::Azure.Response.Mock()
                 );
             });
 

--- a/tests/NetEvolve.HealthChecks.Tests.Unit/Azure.ServiceBus/ServiceBusTopicAdministrationTests.cs
+++ b/tests/NetEvolve.HealthChecks.Tests.Unit/Azure.ServiceBus/ServiceBusTopicAdministrationTests.cs
@@ -1,8 +1,5 @@
 ﻿namespace NetEvolve.HealthChecks.Tests.Unit.Azure.ServiceBus;
 
-using System;
-using System.Diagnostics.CodeAnalysis;
-using System.Threading;
 using System.Threading.Tasks;
 using global::Azure.Messaging.ServiceBus.Administration;
 using Microsoft.Extensions.DependencyInjection;
@@ -10,7 +7,7 @@ using Microsoft.Extensions.Diagnostics.HealthChecks;
 using Microsoft.Extensions.Options;
 using NetEvolve.Extensions.TUnit;
 using NetEvolve.HealthChecks.Azure.ServiceBus;
-using NSubstitute;
+using TUnit.Mocks;
 
 [TestGroup($"{nameof(Azure)}.{nameof(ServiceBus)}")]
 [TestGroup($"{nameof(Azure)}.{nameof(ServiceBus)}.Topic")]
@@ -28,10 +25,10 @@ public sealed class ServiceBusTopicAdministrationTests
             TopicName = "test-topic",
         };
 
-        var optionsMonitor = Substitute.For<IOptionsMonitor<ServiceBusTopicOptions>>();
+        var optionsMonitor = IOptionsMonitor<ServiceBusTopicOptions>.Mock();
         _ = optionsMonitor.Get("test").Returns(options);
 
-        var serviceProvider = Substitute.For<IServiceProvider>();
+        var serviceProvider = IServiceProvider.Mock();
         var healthCheck = new ServiceBusTopicHealthCheck(serviceProvider, optionsMonitor);
 
         var context = new HealthCheckContext
@@ -56,13 +53,14 @@ public sealed class ServiceBusTopicAdministrationTests
             TopicName = "non-existing-topic",
         };
 
-        var optionsMonitor = Substitute.For<IOptionsMonitor<ServiceBusTopicOptions>>();
+        var optionsMonitor = IOptionsMonitor<ServiceBusTopicOptions>.Mock();
         _ = optionsMonitor.Get("test").Returns(options);
 
         // Create a mock service provider with a mock administration client
-        var mockAdminClient = Substitute.For<ServiceBusAdministrationClient>();
+        var mockAdminClient = ServiceBusAdministrationClient.Mock();
+        ServiceBusAdministrationClient registeredAdminClient = mockAdminClient;
         var serviceCollection = new ServiceCollection();
-        _ = serviceCollection.AddSingleton(mockAdminClient);
+        _ = serviceCollection.AddSingleton(registeredAdminClient);
         var serviceProvider = serviceCollection.BuildServiceProvider();
 
         var healthCheck = new ServiceBusTopicHealthCheck(serviceProvider, optionsMonitor);
@@ -74,14 +72,13 @@ public sealed class ServiceBusTopicAdministrationTests
 
         // Setup mock to throw exception to simulate topic not existing
         _ = mockAdminClient
-            .GetTopicRuntimePropertiesAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
-            .Returns<global::Azure.Response<TopicRuntimeProperties>>(_ =>
-            {
-                throw new global::Azure.Messaging.ServiceBus.ServiceBusException(
+            .GetTopicRuntimePropertiesAsync(Any(), Any())
+            .Throws(
+                new global::Azure.Messaging.ServiceBus.ServiceBusException(
                     "Topic not found",
                     global::Azure.Messaging.ServiceBus.ServiceBusFailureReason.MessagingEntityNotFound
-                );
-            });
+                )
+            );
 
         // Act
         var result = await healthCheck.CheckHealthAsync(context);
@@ -91,11 +88,6 @@ public sealed class ServiceBusTopicAdministrationTests
     }
 
     [Test]
-    [SuppressMessage(
-        "Substitute creation",
-        "NS2001:Could not find accessible constructor.",
-        Justification = "Reviewed"
-    )]
     public async Task CheckHealthAsync_WhenTimeout_ShouldReturnUnhealthy()
     {
         // Arrange
@@ -106,13 +98,14 @@ public sealed class ServiceBusTopicAdministrationTests
             Timeout = 1, // Very short timeout to force failure
         };
 
-        var optionsMonitor = Substitute.For<IOptionsMonitor<ServiceBusTopicOptions>>();
+        var optionsMonitor = IOptionsMonitor<ServiceBusTopicOptions>.Mock();
         _ = optionsMonitor.Get("test").Returns(options);
 
         // Create a mock service provider with a mock administration client
-        var mockAdminClient = Substitute.For<ServiceBusAdministrationClient>();
+        var mockAdminClient = ServiceBusAdministrationClient.Mock();
+        ServiceBusAdministrationClient registeredAdminClient = mockAdminClient;
         var serviceCollection = new ServiceCollection();
-        _ = serviceCollection.AddSingleton(mockAdminClient);
+        _ = serviceCollection.AddSingleton(registeredAdminClient);
         var serviceProvider = serviceCollection.BuildServiceProvider();
 
         var healthCheck = new ServiceBusTopicHealthCheck(serviceProvider, optionsMonitor);
@@ -124,13 +117,13 @@ public sealed class ServiceBusTopicAdministrationTests
 
         // Setup mock to delay longer than the timeout
         _ = mockAdminClient
-            .GetTopicRuntimePropertiesAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
-            .Returns(async _ =>
+            .GetTopicRuntimePropertiesAsync(Any(), Any())
+            .ReturnsAsync(async () =>
             {
                 await Task.Delay(100); // Delay longer than the timeout
                 return global::Azure.Response.FromValue(
-                    Substitute.For<TopicRuntimeProperties>(),
-                    Substitute.For<global::Azure.Response>()
+                    global::Azure.Messaging.ServiceBus.ServiceBusModelFactory.TopicRuntimeProperties("timeout-topic"),
+                    global::Azure.Response.Mock()
                 );
             });
 

--- a/tests/NetEvolve.HealthChecks.Tests.Unit/Cassandra/CassandraHealthCheckTests.cs
+++ b/tests/NetEvolve.HealthChecks.Tests.Unit/Cassandra/CassandraHealthCheckTests.cs
@@ -1,6 +1,7 @@
-﻿namespace NetEvolve.HealthChecks.Tests.Unit.Cassandra;
+namespace NetEvolve.HealthChecks.Tests.Unit.Cassandra;
 
-using System.Linq;
+using System.Collections.Concurrent;
+using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.DependencyInjection;
@@ -8,7 +9,7 @@ using Microsoft.Extensions.Diagnostics.HealthChecks;
 using Microsoft.Extensions.Options;
 using NetEvolve.Extensions.TUnit;
 using NetEvolve.HealthChecks.Cassandra;
-using NSubstitute;
+using TUnit.Mocks;
 using CassandraDriver = global::Cassandra;
 
 [TestGroup(nameof(Cassandra))]
@@ -16,17 +17,32 @@ public class CassandraHealthCheckTests
 {
     private const string TestName = nameof(Cassandra);
 
+    // CassandraDriver.RowSet is a concrete class whose GetEnumerator() reads from a protected
+    // RowQueue property; TUnit.Mocks' partial-mock subclass triggers a virtual-dispatch NRE
+    // because the driver's own constructor assigns RowQueue before the mock's tracking state is
+    // initialized. Constructing a real RowSet and populating RowQueue via reflection sidesteps
+    // the generator bug entirely while still exercising real driver enumeration behavior.
+    private static CassandraDriver.RowSet CreateRowSet(params CassandraDriver.Row[] rows)
+    {
+        var rowSet = new CassandraDriver.RowSet();
+        var rowQueueProperty = typeof(CassandraDriver.RowSet).GetProperty(
+            "RowQueue",
+            BindingFlags.Instance | BindingFlags.NonPublic
+        )!;
+        rowQueueProperty.SetValue(rowSet, new ConcurrentQueue<CassandraDriver.Row>(rows));
+        return rowSet;
+    }
+
     [Test]
     public async Task DefaultCommandAsync_WhenClusterAvailable_ReturnsTrue()
     {
         // Arrange
-        var cluster = Substitute.For<CassandraDriver.ICluster>();
-        var session = Substitute.For<CassandraDriver.ISession>();
-        var rowSet = Substitute.For<CassandraDriver.RowSet>();
+        var cluster = CassandraDriver.ICluster.Mock();
+        var session = CassandraDriver.ISession.Mock();
+        using var rowSet = CreateRowSet(new CassandraDriver.Row());
 
-        _ = cluster.ConnectAsync().Returns(Task.FromResult(session));
-        _ = session.ExecuteAsync(Arg.Any<CassandraDriver.IStatement>()).Returns(Task.FromResult(rowSet));
-        _ = rowSet.GetEnumerator().Returns(Enumerable.Repeat(Substitute.For<CassandraDriver.Row>(), 1).GetEnumerator());
+        _ = cluster.ConnectAsync().Returns(session);
+        _ = session.ExecuteAsync(Any<CassandraDriver.IStatement>()).Returns(rowSet);
 
         // Act
         var result = await CassandraHealthCheck.DefaultCommandAsync(cluster, CancellationToken.None);
@@ -39,13 +55,11 @@ public class CassandraHealthCheckTests
     public async Task DefaultCommandAsync_WhenResultIsNull_ReturnsFalse()
     {
         // Arrange
-        var cluster = Substitute.For<CassandraDriver.ICluster>();
-        var session = Substitute.For<CassandraDriver.ISession>();
+        var cluster = CassandraDriver.ICluster.Mock();
+        var session = CassandraDriver.ISession.Mock();
 
-        _ = cluster.ConnectAsync().Returns(Task.FromResult(session));
-        _ = session
-            .ExecuteAsync(Arg.Any<CassandraDriver.IStatement>())
-            .Returns(Task.FromResult<CassandraDriver.RowSet>(null!));
+        _ = cluster.ConnectAsync().Returns(session);
+        _ = session.ExecuteAsync(Any<CassandraDriver.IStatement>()).Returns((CassandraDriver.RowSet)null!);
 
         // Act
         var result = await CassandraHealthCheck.DefaultCommandAsync(cluster, CancellationToken.None);
@@ -58,13 +72,12 @@ public class CassandraHealthCheckTests
     public async Task DefaultCommandAsync_WhenResultIsEmpty_ReturnsFalse()
     {
         // Arrange
-        var cluster = Substitute.For<CassandraDriver.ICluster>();
-        var session = Substitute.For<CassandraDriver.ISession>();
-        var rowSet = Substitute.For<CassandraDriver.RowSet>();
+        var cluster = CassandraDriver.ICluster.Mock();
+        var session = CassandraDriver.ISession.Mock();
+        using var rowSet = CreateRowSet();
 
-        _ = cluster.ConnectAsync().Returns(Task.FromResult(session));
-        _ = session.ExecuteAsync(Arg.Any<CassandraDriver.IStatement>()).Returns(Task.FromResult(rowSet));
-        _ = rowSet.GetEnumerator().Returns(Enumerable.Empty<CassandraDriver.Row>().GetEnumerator());
+        _ = cluster.ConnectAsync().Returns(session);
+        _ = session.ExecuteAsync(Any<CassandraDriver.IStatement>()).Returns(rowSet);
 
         // Act
         var result = await CassandraHealthCheck.DefaultCommandAsync(cluster, CancellationToken.None);
@@ -77,7 +90,7 @@ public class CassandraHealthCheckTests
     public async Task CheckHealthAsync_WhenCommandReturnsFalse_ShouldReturnUnhealthyWithMessage()
     {
         // Arrange
-        var cluster = Substitute.For<CassandraDriver.ICluster>();
+        var cluster = CassandraDriver.ICluster.Mock();
         var options = new CassandraOptions
         {
             KeyedService = null,
@@ -89,11 +102,11 @@ public class CassandraHealthCheckTests
             },
         };
 
-        var optionsMonitor = Substitute.For<IOptionsMonitor<CassandraOptions>>();
+        var optionsMonitor = IOptionsMonitor<CassandraOptions>.Mock();
         _ = optionsMonitor.Get(TestName).Returns(options);
 
         var serviceCollection = new ServiceCollection();
-        _ = serviceCollection.AddSingleton(cluster);
+        _ = serviceCollection.AddSingleton<CassandraDriver.ICluster>(cluster);
         var serviceProvider = serviceCollection.BuildServiceProvider();
 
         var healthCheck = new CassandraHealthCheck(serviceProvider, optionsMonitor);
@@ -119,7 +132,7 @@ public class CassandraHealthCheckTests
     public async Task CheckHealthAsync_WhenCommandReturnsTrue_ShouldReturnHealthy()
     {
         // Arrange
-        var cluster = Substitute.For<CassandraDriver.ICluster>();
+        var cluster = CassandraDriver.ICluster.Mock();
         var options = new CassandraOptions
         {
             KeyedService = null,
@@ -131,11 +144,11 @@ public class CassandraHealthCheckTests
             },
         };
 
-        var optionsMonitor = Substitute.For<IOptionsMonitor<CassandraOptions>>();
+        var optionsMonitor = IOptionsMonitor<CassandraOptions>.Mock();
         _ = optionsMonitor.Get(TestName).Returns(options);
 
         var serviceCollection = new ServiceCollection();
-        _ = serviceCollection.AddSingleton(cluster);
+        _ = serviceCollection.AddSingleton<CassandraDriver.ICluster>(cluster);
         var serviceProvider = serviceCollection.BuildServiceProvider();
 
         var healthCheck = new CassandraHealthCheck(serviceProvider, optionsMonitor);

--- a/tests/NetEvolve.HealthChecks.Tests.Unit/Elasticsearch/ElasticsearchHealthCheckTests.cs
+++ b/tests/NetEvolve.HealthChecks.Tests.Unit/Elasticsearch/ElasticsearchHealthCheckTests.cs
@@ -9,7 +9,7 @@ using Microsoft.Extensions.Diagnostics.HealthChecks;
 using Microsoft.Extensions.Options;
 using NetEvolve.Extensions.TUnit;
 using NetEvolve.HealthChecks.Elasticsearch;
-using NSubstitute;
+using TUnit.Mocks;
 
 [TestGroup(nameof(Elasticsearch))]
 public sealed class ElasticsearchHealthCheckTests
@@ -20,8 +20,8 @@ public sealed class ElasticsearchHealthCheckTests
     public async Task CheckHealthAsync_WhenContextNull_ThrowArgumentNullException()
     {
         // Arrange
-        var serviceProvider = Substitute.For<IServiceProvider>();
-        var optionsMonitor = Substitute.For<IOptionsMonitor<ElasticsearchOptions>>();
+        var serviceProvider = IServiceProvider.Mock();
+        var optionsMonitor = IOptionsMonitor<ElasticsearchOptions>.Mock();
         using var check = new ElasticsearchHealthCheck(serviceProvider, optionsMonitor);
 
         // Act
@@ -35,8 +35,8 @@ public sealed class ElasticsearchHealthCheckTests
     public async Task CheckHealthAsync_WhenCancellationTokenIsCancelled_ShouldReturnUnhealthy()
     {
         // Arrange
-        var serviceProvider = Substitute.For<IServiceProvider>();
-        var optionsMonitor = Substitute.For<IOptionsMonitor<ElasticsearchOptions>>();
+        var serviceProvider = IServiceProvider.Mock();
+        var optionsMonitor = IOptionsMonitor<ElasticsearchOptions>.Mock();
 
         using var check = new ElasticsearchHealthCheck(serviceProvider, optionsMonitor);
         var context = new HealthCheckContext
@@ -62,8 +62,8 @@ public sealed class ElasticsearchHealthCheckTests
     public async Task CheckHealthAsync_WhenOptionsAreNull_ShouldReturnUnhealthy()
     {
         // Arrange
-        var serviceProvider = Substitute.For<IServiceProvider>();
-        var optionsMonitor = Substitute.For<IOptionsMonitor<ElasticsearchOptions>>();
+        var serviceProvider = IServiceProvider.Mock();
+        var optionsMonitor = IOptionsMonitor<ElasticsearchOptions>.Mock();
 
         using var check = new ElasticsearchHealthCheck(serviceProvider, optionsMonitor);
         var context = new HealthCheckContext
@@ -101,12 +101,12 @@ public sealed class ElasticsearchHealthCheckTests
             },
         };
 
-        var optionsMonitor = Substitute.For<IOptionsMonitor<ElasticsearchOptions>>();
+        var optionsMonitor = IOptionsMonitor<ElasticsearchOptions>.Mock();
         _ = optionsMonitor.Get(TestName).Returns(options);
 
-        // Setup client mock that returns success
-        var uri = Substitute.For<Uri>("http://localhost/test");
-        var settings = Substitute.For<ElasticsearchClientSettings>(uri);
+        // Setup client that returns success
+        var uri = new Uri("http://localhost/test");
+        var settings = ElasticsearchClientSettings.Mock(uri).Object;
         var client = new ElasticsearchClient(settings);
 
         var serviceProvider = new ServiceCollection().AddKeyedSingleton(serviceKey, client).BuildServiceProvider();
@@ -151,12 +151,12 @@ public sealed class ElasticsearchHealthCheckTests
             },
         };
 
-        var optionsMonitor = Substitute.For<IOptionsMonitor<ElasticsearchOptions>>();
+        var optionsMonitor = IOptionsMonitor<ElasticsearchOptions>.Mock();
         _ = optionsMonitor.Get(TestName).Returns(options);
 
-        // Setup connection mock that returns success
-        var uri = Substitute.For<Uri>("http://localhost/test");
-        var settings = Substitute.For<ElasticsearchClientSettings>(uri);
+        // Setup connection that returns success
+        var uri = new Uri("http://localhost/test");
+        var settings = ElasticsearchClientSettings.Mock(uri).Object;
         var client = new ElasticsearchClient(settings);
 
         var serviceProvider = new ServiceCollection().AddSingleton(client).BuildServiceProvider();
@@ -201,12 +201,12 @@ public sealed class ElasticsearchHealthCheckTests
             },
         };
 
-        var optionsMonitor = Substitute.For<IOptionsMonitor<ElasticsearchOptions>>();
+        var optionsMonitor = IOptionsMonitor<ElasticsearchOptions>.Mock();
         _ = optionsMonitor.Get(TestName).Returns(options);
 
-        // Setup connection mock that throws an exception
-        var uri = Substitute.For<Uri>("http://localhost/test");
-        var settings = Substitute.For<ElasticsearchClientSettings>(uri);
+        // Setup connection that throws an exception
+        var uri = new Uri("http://localhost/test");
+        var settings = ElasticsearchClientSettings.Mock(uri).Object;
         var client = new ElasticsearchClient(settings);
 
         var serviceProvider = new ServiceCollection().AddSingleton(client).BuildServiceProvider();

--- a/tests/NetEvolve.HealthChecks.Tests.Unit/NetEvolve.HealthChecks.Tests.Unit.csproj
+++ b/tests/NetEvolve.HealthChecks.Tests.Unit/NetEvolve.HealthChecks.Tests.Unit.csproj
@@ -16,37 +16,6 @@
     <PackageReference Include="Minio" />
     <PackageReference Include="NATS.Client" />
     <PackageReference Include="NetEvolve.Extensions.TUnit" />
-    <!--
-      NSubstitute is retained for a handful of files that TUnit.Mocks 1.61.38's alpha source
-      generator can't (yet) handle. Remove once the linked upstream issues are fixed and these
-      files are migrated too:
-        - RavenDb: mocking IDocumentStore fails (nested ISessionBlittableJsonConverter member
-          with asymmetric property accessors, CS0535/CS0548/CS0551).
-          https://github.com/thomhurst/TUnit/issues/6491
-        - Elasticsearch: mocking ElasticsearchClientSettings fails (generator emits an invalid
-          nullable-type pattern, CS8116).
-          https://github.com/thomhurst/TUnit/issues/6492
-        - Azure.ServiceBus (Queue/Subscription/Topic Administration): mocking
-          ServiceBusAdministrationClient pulls in QueueRuntimeProperties/
-          SubscriptionRuntimeProperties/TopicRuntimeProperties, none of which have an accessible
-          parameterless constructor (CS1729).
-          https://github.com/thomhurst/TUnit/issues/6493
-        - Cassandra: mocking Cassandra.ICluster collides with Couchbase.ICluster (also mocked in
-          this project, see Couchbase/CouchbaseHealthCheckTests.cs) - the generator names the
-          wrapper type "IClusterMock" without namespace-qualifying it, so having both interfaces
-          mocked in the same compilation silently breaks one of them (CS1061: generated wrapper
-          is missing the real interface's members entirely).
-          https://github.com/thomhurst/TUnit/issues/6494
-        - RabbitMQ: one test only (CheckHealthAsync_WhenTimeout_ReturnsDegraded) - .Returns() only
-          accepts a synchronous Func<T>, so a mocked call can't hand back a task that stays pending
-          and completes later, which this test's genuine async timeout-race depends on.
-          https://github.com/thomhurst/TUnit/issues/6495
-    -->
-    <PackageReference Include="NSubstitute" />
-    <PackageReference Include="NSubstitute.Analyzers.CSharp">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
     <PackageReference Include="TUnit" />
     <PackageReference Include="TUnit.Mocks" />
   </ItemGroup>

--- a/tests/NetEvolve.HealthChecks.Tests.Unit/RabbitMQ/RabbitMQHealthCheckTests.cs
+++ b/tests/NetEvolve.HealthChecks.Tests.Unit/RabbitMQ/RabbitMQHealthCheckTests.cs
@@ -158,9 +158,7 @@ public sealed class RabbitMQHealthCheckTests
         var mockChannel = IChannel.Mock();
         _ = mockChannel.IsOpen.Returns(true);
         var mockConnection = IConnection.Mock();
-        _ = mockConnection
-            .CreateChannelAsync(Any(), Any())
-            .ReturnsAsync(() => DelayedChannelAsync(mockChannel));
+        _ = mockConnection.CreateChannelAsync(Any(), Any()).ReturnsAsync(() => DelayedChannelAsync(mockChannel));
 
         var serviceCollection = new ServiceCollection();
         _ = serviceCollection.AddSingleton<IConnection>(mockConnection);

--- a/tests/NetEvolve.HealthChecks.Tests.Unit/RabbitMQ/RabbitMQHealthCheckTests.cs
+++ b/tests/NetEvolve.HealthChecks.Tests.Unit/RabbitMQ/RabbitMQHealthCheckTests.cs
@@ -10,7 +10,6 @@ using Microsoft.Extensions.Diagnostics.HealthChecks;
 using Microsoft.Extensions.Options;
 using NetEvolve.Extensions.TUnit;
 using NetEvolve.HealthChecks.RabbitMQ;
-using NSubstitute;
 using TUnit.Mocks;
 
 [TestGroup(nameof(RabbitMQ))]
@@ -138,6 +137,11 @@ public sealed class RabbitMQHealthCheckTests
     }
 
     [Test]
+    [SuppressMessage(
+        "Reliability",
+        "CA2025:Do not pass 'IDisposable' instances into unawaited tasks",
+        Justification = "As designed."
+    )]
     public async Task CheckHealthAsync_WhenTimeout_ReturnsDegraded()
     {
         // Arrange
@@ -147,27 +151,19 @@ public sealed class RabbitMQHealthCheckTests
             Timeout = 1, // Very short timeout to force a timeout
         };
 
-        // TUnit.Mocks' .Returns() only supports a synchronous Func<T> (auto-wrapped into a
-        // completed Task<T>) - there's no way to hand back a task that stays pending and
-        // completes asynchronously later, so a genuine timeout-race can't be simulated with it.
-        // NSubstitute is used here instead, purely for this one test.
-        var optionsMonitor = NSubstitute.Substitute.For<IOptionsMonitor<RabbitMQOptions>>();
+        var optionsMonitor = IOptionsMonitor<RabbitMQOptions>.Mock();
         _ = optionsMonitor.Get(TestName).Returns(options);
 
         // Setup connection mock that delays long enough to cause timeout
-        var mockChannel = NSubstitute.Substitute.For<IChannel>();
+        var mockChannel = IChannel.Mock();
         _ = mockChannel.IsOpen.Returns(true);
-        var mockConnection = NSubstitute.Substitute.For<IConnection>();
+        var mockConnection = IConnection.Mock();
         _ = mockConnection
-            .CreateChannelAsync(NSubstitute.Arg.Any<CreateChannelOptions>(), NSubstitute.Arg.Any<CancellationToken>())
-            .Returns(async _ =>
-            {
-                await Task.Delay(50); // Delay to force timeout
-                return mockChannel;
-            });
+            .CreateChannelAsync(Any(), Any())
+            .ReturnsAsync(() => DelayedChannelAsync(mockChannel));
 
         var serviceCollection = new ServiceCollection();
-        _ = serviceCollection.AddSingleton(mockConnection);
+        _ = serviceCollection.AddSingleton<IConnection>(mockConnection);
         var serviceProvider = serviceCollection.BuildServiceProvider();
 
         var healthCheck = new RabbitMQHealthCheck(serviceProvider, optionsMonitor);
@@ -185,5 +181,13 @@ public sealed class RabbitMQHealthCheckTests
             _ = await Assert.That(result.Status).IsEqualTo(HealthStatus.Degraded);
             _ = await Assert.That(result.Description).IsEqualTo($"{TestName}: Degraded", StringComparison.Ordinal);
         }
+    }
+
+    // Genuinely delays before completing, so the created channel task stays pending long
+    // enough for the health check's timeout to elapse first.
+    private static async Task<IChannel> DelayedChannelAsync(IChannel channel)
+    {
+        await Task.Delay(50);
+        return channel;
     }
 }

--- a/tests/NetEvolve.HealthChecks.Tests.Unit/RavenDb/RavenDbHealthCheckTests.cs
+++ b/tests/NetEvolve.HealthChecks.Tests.Unit/RavenDb/RavenDbHealthCheckTests.cs
@@ -1,4 +1,4 @@
-﻿namespace NetEvolve.HealthChecks.Tests.Unit.RavenDb;
+namespace NetEvolve.HealthChecks.Tests.Unit.RavenDb;
 
 using System;
 using System.Threading;
@@ -8,9 +8,9 @@ using Microsoft.Extensions.Diagnostics.HealthChecks;
 using Microsoft.Extensions.Options;
 using NetEvolve.Extensions.TUnit;
 using NetEvolve.HealthChecks.RavenDb;
-using NSubstitute;
 using Raven.Client.Documents;
 using Raven.Client.Exceptions;
+using TUnit.Mocks;
 
 [TestGroup(nameof(RavenDb))]
 public sealed class RavenDbHealthCheckTests
@@ -21,8 +21,8 @@ public sealed class RavenDbHealthCheckTests
     public async Task CheckHealthAsync_WhenContextNull_ThrowArgumentNullException()
     {
         // Arrange
-        var serviceProvider = Substitute.For<IServiceProvider>();
-        var optionsMonitor = Substitute.For<IOptionsMonitor<RavenDbOptions>>();
+        var serviceProvider = IServiceProvider.Mock();
+        var optionsMonitor = IOptionsMonitor<RavenDbOptions>.Mock();
         var check = new RavenDbHealthCheck(serviceProvider, optionsMonitor);
 
         // Act
@@ -36,8 +36,8 @@ public sealed class RavenDbHealthCheckTests
     public async Task CheckHealthAsync_WhenCancellationTokenIsCancelled_ShouldReturnUnhealthy()
     {
         // Arrange
-        var serviceProvider = Substitute.For<IServiceProvider>();
-        var optionsMonitor = Substitute.For<IOptionsMonitor<RavenDbOptions>>();
+        var serviceProvider = IServiceProvider.Mock();
+        var optionsMonitor = IOptionsMonitor<RavenDbOptions>.Mock();
 
         var check = new RavenDbHealthCheck(serviceProvider, optionsMonitor);
         var context = new HealthCheckContext
@@ -61,8 +61,8 @@ public sealed class RavenDbHealthCheckTests
     public async Task CheckHealthAsync_WhenOptionsAreNull_ShouldReturnUnhealthy()
     {
         // Arrange
-        var serviceProvider = Substitute.For<IServiceProvider>();
-        var optionsMonitor = Substitute.For<IOptionsMonitor<RavenDbOptions>>();
+        var serviceProvider = IServiceProvider.Mock();
+        var optionsMonitor = IOptionsMonitor<RavenDbOptions>.Mock();
 
         var check = new RavenDbHealthCheck(serviceProvider, optionsMonitor);
         var context = new HealthCheckContext
@@ -96,14 +96,14 @@ public sealed class RavenDbHealthCheckTests
             },
         };
 
-        var optionsMonitor = Substitute.For<IOptionsMonitor<RavenDbOptions>>();
+        var optionsMonitor = IOptionsMonitor<RavenDbOptions>.Mock();
         _ = optionsMonitor.Get(TestName).Returns(options);
 
         // Setup client mock that returns success
-        var store = Substitute.For<IDocumentStore>();
+        var store = IDocumentStore.Mock();
 
         var serviceCollection = new ServiceCollection();
-        _ = serviceCollection.AddKeyedSingleton("test-key", store);
+        _ = serviceCollection.AddKeyedSingleton<IDocumentStore>("test-key", store);
         var serviceProvider = serviceCollection.BuildServiceProvider();
 
         var healthCheck = new RavenDbHealthCheck(serviceProvider, optionsMonitor);
@@ -138,14 +138,14 @@ public sealed class RavenDbHealthCheckTests
             },
         };
 
-        var optionsMonitor = Substitute.For<IOptionsMonitor<RavenDbOptions>>();
+        var optionsMonitor = IOptionsMonitor<RavenDbOptions>.Mock();
         _ = optionsMonitor.Get(TestName).Returns(options);
 
         // Setup connection mock that returns success
-        var store = Substitute.For<IDocumentStore>();
+        var store = IDocumentStore.Mock();
 
         var serviceCollection = new ServiceCollection();
-        _ = serviceCollection.AddSingleton(store);
+        _ = serviceCollection.AddSingleton<IDocumentStore>(store);
         var serviceProvider = serviceCollection.BuildServiceProvider();
 
         var healthCheck = new RavenDbHealthCheck(serviceProvider, optionsMonitor);
@@ -180,14 +180,14 @@ public sealed class RavenDbHealthCheckTests
             },
         };
 
-        var optionsMonitor = Substitute.For<IOptionsMonitor<RavenDbOptions>>();
+        var optionsMonitor = IOptionsMonitor<RavenDbOptions>.Mock();
         _ = optionsMonitor.Get(TestName).Returns(options);
 
         // Setup connection mock that throws an exception
-        var store = Substitute.For<IDocumentStore>();
+        var store = IDocumentStore.Mock();
 
         var serviceCollection = new ServiceCollection();
-        _ = serviceCollection.AddSingleton(store);
+        _ = serviceCollection.AddSingleton<IDocumentStore>(store);
         var serviceProvider = serviceCollection.BuildServiceProvider();
 
         var healthCheck = new RavenDbHealthCheck(serviceProvider, optionsMonitor);


### PR DESCRIPTION
## Summary
- TUnit.Mocks 1.62.0 fixes the five upstream generator bugs (thomhurst/TUnit#6491-#6495) that previously forced NSubstitute usage in a handful of test files (RavenDb, Elasticsearch, Azure.ServiceBus administration, Cassandra, RabbitMQ)
- Bump `TUnit`/`TUnit.Mocks` to 1.62.0 in `Directory.Packages.props`
- Migrate the remaining NSubstitute-based tests to TUnit.Mocks and drop the `NSubstitute`/`NSubstitute.Analyzers.CSharp` package references entirely

## Test plan
- [x] `dotnet test tests/NetEvolve.HealthChecks.Tests.Unit/NetEvolve.HealthChecks.Tests.Unit.csproj -f net10.0` — 1865/1865 passing
- [x] No remaining references to `NSubstitute` anywhere in the repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)