### PR TITLE
feat(seq): add health check for Seq

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -109,6 +109,7 @@
     <PackageVersion Include="RabbitMQ.Client" Version="7.2.1" />
     <PackageVersion Include="RavenDB.Client" Version="7.2.5" />
     <PackageVersion Include="RocketMQ.Client" Version="5.2.1" />
+    <PackageVersion Include="Seq.Api" Version="2026.1.0" />
     <PackageVersion Include="SharpCompress" Version="0.50.3" />
     <PackageVersion Include="Snappier" Version="1.3.1" />
     <PackageVersion Include="SolrNet.Core" Version="1.2.1" />
@@ -167,6 +168,7 @@
     <PackageVersion Include="Testcontainers.RavenDb" Version="4.13.0" />
     <PackageVersion Include="Testcontainers.Redis" Version="4.13.0" />
     <PackageVersion Include="Testcontainers.Redpanda" Version="4.13.0" />
+    <PackageVersion Include="Testcontainers.Seq" Version="4.13.0" />
     <PackageVersion Include="Testcontainers.ServiceBus" Version="4.13.0" />
     <PackageVersion Include="TngTech.ArchUnitNET.TUnit" Version="0.13.3" />
     <PackageVersion Include="TUnit" Version="1.62.0" />

--- a/HealthChecks.slnx
+++ b/HealthChecks.slnx
@@ -96,6 +96,7 @@
     <Project Path="src/NetEvolve.HealthChecks.RavenDb/NetEvolve.HealthChecks.RavenDb.csproj" />
     <Project Path="src/NetEvolve.HealthChecks.Redis/NetEvolve.HealthChecks.Redis.csproj" />
     <Project Path="src/NetEvolve.HealthChecks.Redpanda/NetEvolve.HealthChecks.Redpanda.csproj" />
+    <Project Path="src/NetEvolve.HealthChecks.Seq/NetEvolve.HealthChecks.Seq.csproj" />
     <Project Path="src/NetEvolve.HealthChecks.SQLite.Devart/NetEvolve.HealthChecks.SQLite.Devart.csproj" />
     <Project Path="src/NetEvolve.HealthChecks.SQLite.Legacy/NetEvolve.HealthChecks.SQLite.Legacy.csproj" />
     <Project Path="src/NetEvolve.HealthChecks.SQLite/NetEvolve.HealthChecks.SQLite.csproj" />

--- a/src/NetEvolve.HealthChecks.Seq/DependencyInjectionExtensions.cs
+++ b/src/NetEvolve.HealthChecks.Seq/DependencyInjectionExtensions.cs
@@ -1,0 +1,65 @@
+namespace NetEvolve.HealthChecks.Seq;
+
+using System;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using SourceGenerator.Attributes;
+
+/// <summary>
+/// Extensions methods for <see cref="IHealthChecksBuilder"/> with custom Health Checks.
+/// </summary>
+[HealthCheckHelper]
+public static partial class DependencyInjectionExtensions
+{
+    private static readonly string[] _defaultTags = ["seq", "logging"];
+
+    /// <summary>
+    /// Add a health check for the Seq service.
+    /// </summary>
+    /// <param name="builder">The <see cref="IHealthChecksBuilder"/>.</param>
+    /// <param name="name">The name of the <see cref="SeqHealthCheck"/>.</param>
+    /// <param name="options">An optional action to configure.</param>
+    /// <param name="tags">A list of additional tags that can be used to filter sets of health checks. Optional.</param>
+    /// <exception cref="ArgumentNullException">The <paramref name="builder"/> is <see langword="null" />.</exception>
+    /// <exception cref="ArgumentNullException">The <paramref name="name"/> is <see langword="null" />.</exception>
+    /// <exception cref="ArgumentException">The <paramref name="name"/> is <see langword="null" /> or <c>whitespace</c>.</exception>
+    /// <exception cref="ArgumentException">The <paramref name="name"/> is already in use.</exception>
+    /// <exception cref="ArgumentNullException">The <paramref name="tags"/> is <see langword="null" />.</exception>
+    public static IHealthChecksBuilder AddSeq(
+        [NotNull] this IHealthChecksBuilder builder,
+        [NotNull] string name,
+        Action<SeqOptions>? options = null,
+        params string[] tags
+    )
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+        ArgumentException.ThrowIfNullOrEmpty(name);
+        ArgumentNullException.ThrowIfNull(tags);
+
+        if (!builder.IsServiceTypeRegistered<SeqCheckMarker>())
+        {
+            _ = builder
+                .Services.AddSingleton<SeqCheckMarker>()
+                .AddSingleton<SeqHealthCheck>()
+                .AddSingleton<SeqClientProvider>()
+                .ConfigureOptions<SeqConfigure>();
+        }
+
+        builder.ThrowIfNameIsAlreadyUsed<SeqHealthCheck>(name);
+
+        if (options is not null)
+        {
+            _ = builder.Services.Configure(name, options);
+        }
+
+        return builder.AddCheck<SeqHealthCheck>(
+            name,
+            HealthStatus.Unhealthy,
+            _defaultTags.Union(tags, StringComparer.OrdinalIgnoreCase)
+        );
+    }
+
+    private sealed partial class SeqCheckMarker;
+}

--- a/src/NetEvolve.HealthChecks.Seq/NetEvolve.HealthChecks.Seq.csproj
+++ b/src/NetEvolve.HealthChecks.Seq/NetEvolve.HealthChecks.Seq.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFrameworks>$(_ProjectTargetFrameworks)</TargetFrameworks>
+    <Description>Contains HealthChecks for the Seq service, based on the nuget package `Seq.Api`.</Description>
+    <PackageTags>$(PackageTags);seq;logging</PackageTags>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Seq.Api" />
+    <PackageReference Include="NetEvolve.Extensions.Tasks" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\SourceGenerator.Attributes\SourceGenerator.Attributes.csproj" PrivateAssets="all" />
+    <ProjectReference Include="..\SourceGenerator.HealthChecks\SourceGenerator.HealthChecks.csproj" ReferenceOutputAssembly="false" OutputItemType="Analyzer" />
+  </ItemGroup>
+</Project>

--- a/src/NetEvolve.HealthChecks.Seq/README.md
+++ b/src/NetEvolve.HealthChecks.Seq/README.md
@@ -1,0 +1,90 @@
+# NetEvolve.HealthChecks.Seq
+
+[![NuGet](https://img.shields.io/nuget/v/NetEvolve.HealthChecks.Seq?logo=nuget)](https://www.nuget.org/packages/NetEvolve.HealthChecks.Seq/)
+[![NuGet](https://img.shields.io/nuget/dt/NetEvolve.HealthChecks.Seq?logo=nuget)](https://www.nuget.org/packages/NetEvolve.HealthChecks.Seq/)
+
+This package provides a health check for the [Seq](https://datalust.co/seq) logging server, based on the [Seq.Api](https://www.nuget.org/packages/Seq.Api/) package. The main purpose is to check if the Seq server is available.
+
+:bulb: This package is available for .NET 8.0 and later.
+
+## Installation
+To use this package, you need to add the package to your project. You can do this by using the NuGet package manager or by using the dotnet CLI.
+```powershell
+dotnet add package NetEvolve.HealthChecks.Seq
+```
+
+## Health Check - Seq Liveness
+The health check is a liveness check. It checks if the Seq server is reachable and available.
+If the query needs longer than the configured timeout, the health check will return `Degraded`.
+If the query fails, for whatever reason, the health check will return `Unhealthy`.
+
+### Usage
+After adding the package, you need to import the namespace and add the health check to the health check builder.
+```csharp
+using NetEvolve.HealthChecks.Seq;
+```
+Therefore, you can use two different approaches. In both approaches you have to provide a name for the health check.
+
+### Parameters
+- `name`: The name of the health check. The name is used to identify the configuration object. It is required and must be unique within the application.
+- `options`: The configuration options for the health check. If you don't provide any options, the health check will use the configuration based approach.
+- `tags`: The tags for the health check. The tags `seq` and `logging` are always used as default and combined with the user input. You can provide additional tags to group or filter the health checks.
+
+### Variant 1: Configuration based
+The first one is to use the configuration based approach. This approach is recommended if you have multiple Seq instances to check.
+```csharp
+var builder = services.AddHealthChecks();
+
+builder.AddSeq("<name>");
+```
+
+The configuration looks like this:
+```json
+{
+  ..., // other configuration
+  "HealthChecks": {
+    "Seq": {
+      "<name>": {
+        "Mode": "<client_creation_mode>", // Optional, defaults to 'SeqClientCreationMode.ServiceProvider'
+        "KeyedService": "<key>", // Optional, used when Mode set to 'SeqClientCreationMode.ServiceProvider'
+        "ServerUrl": "<server_url>", // Required when Mode set to 'SeqClientCreationMode.ServerUrl'
+        "ApiKey": "<api_key>", // Optional, used when Mode set to 'SeqClientCreationMode.ServerUrl'
+        "Timeout": "<timeout>" // Optional, default is 100 milliseconds
+      }
+    }
+  }
+}
+```
+
+### Variant 2: Builder based
+The second approach is to use the builder based approach. This approach is recommended if you only have one server instance to check or dynamic programmatic values.
+```csharp
+var builder = services.AddHealthChecks();
+
+builder.AddSeq("<name>", options =>
+{
+    options.Mode = <client_creation_mode>; // Optional, defaults to 'SeqClientCreationMode.ServiceProvider'
+    options.KeyedService = "<key>"; // Optional, used when Mode set to 'SeqClientCreationMode.ServiceProvider'
+    options.ServerUrl = "<server_url>"; // Required when Mode set to 'SeqClientCreationMode.ServerUrl'
+    options.ApiKey = "<api_key>"; // Optional, used when Mode set to 'SeqClientCreationMode.ServerUrl'
+    options.Timeout = <timeout>; // Optional, defaults to 100 milliseconds
+
+    // Optional, defaults to NetEvolve.HealthChecks.Seq.SeqHealthCheck.DefaultCommandAsync
+    options.CommandAsync = async (connection, cancellationToken) => {
+        // Your custom server pinging logic goes here.
+        // Should return true if the command result is valid, false otherwise.
+    };
+});
+```
+
+### :bulb: You can always provide tags to all health checks, for grouping or filtering.
+
+```csharp
+var builder = services.AddHealthChecks();
+
+builder.AddSeq("<name>", options => ..., "Seq", "observability");
+```
+
+## License
+
+This project is licensed under the MIT License - see the [LICENSE](https://raw.githubusercontent.com/dailydevops/healthchecks/refs/heads/main/LICENSE) file for details.

--- a/src/NetEvolve.HealthChecks.Seq/SeqClientCreationMode.cs
+++ b/src/NetEvolve.HealthChecks.Seq/SeqClientCreationMode.cs
@@ -1,0 +1,23 @@
+namespace NetEvolve.HealthChecks.Seq;
+
+using global::Seq.Api;
+
+/// <summary>
+/// Describes the mode used to create the <see cref="SeqConnection"/>.
+/// </summary>
+public enum SeqClientCreationMode
+{
+    /// <summary>
+    /// The <see cref="SeqConnection"/> preregistered instance is retrieved from the <see cref="System.IServiceProvider"/>.
+    /// </summary>
+    /// <remarks>
+    /// This is the default mode.
+    /// </remarks>
+    ServiceProvider = 0,
+
+    /// <summary>
+    /// The <see cref="SeqConnection"/> instance is created using the <see cref="SeqOptions.ServerUrl"/>
+    /// and the optional <see cref="SeqOptions.ApiKey"/>.
+    /// </summary>
+    ServerUrl = 1,
+}

--- a/src/NetEvolve.HealthChecks.Seq/SeqClientProvider.cs
+++ b/src/NetEvolve.HealthChecks.Seq/SeqClientProvider.cs
@@ -1,0 +1,39 @@
+namespace NetEvolve.HealthChecks.Seq;
+
+using System;
+using System.Collections.Concurrent;
+using global::Seq.Api;
+using Microsoft.Extensions.DependencyInjection;
+
+internal sealed class SeqClientProvider
+{
+    private ConcurrentDictionary<string, SeqConnection>? _seqConnections;
+
+    internal SeqConnection GetClient(string name, SeqOptions options, IServiceProvider serviceProvider)
+    {
+        if (options.Mode == SeqClientCreationMode.ServiceProvider)
+        {
+            return string.IsNullOrWhiteSpace(options.KeyedService)
+                ? serviceProvider.GetRequiredService<SeqConnection>()
+                : serviceProvider.GetRequiredKeyedService<SeqConnection>(options.KeyedService);
+        }
+
+        _seqConnections ??= new ConcurrentDictionary<string, SeqConnection>(StringComparer.OrdinalIgnoreCase);
+
+        return _seqConnections.GetOrAdd(name, _ => CreateClient(options));
+    }
+
+    internal static SeqConnection CreateClient(SeqOptions options) =>
+        options.Mode switch
+        {
+            SeqClientCreationMode.ServerUrl => CreateClientWithServerUrl(options),
+            _ => throw new ArgumentOutOfRangeException(nameof(options), options.Mode, "The mode is not supported."),
+        };
+
+    private static SeqConnection CreateClientWithServerUrl(SeqOptions options)
+    {
+        ArgumentNullException.ThrowIfNull(options.ServerUrl);
+
+        return new SeqConnection(options.ServerUrl.ToString(), options.ApiKey);
+    }
+}

--- a/src/NetEvolve.HealthChecks.Seq/SeqConfigure.cs
+++ b/src/NetEvolve.HealthChecks.Seq/SeqConfigure.cs
@@ -1,0 +1,89 @@
+namespace NetEvolve.HealthChecks.Seq;
+
+using System;
+using System.Threading;
+using global::Seq.Api;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using static Microsoft.Extensions.Options.ValidateOptionsResult;
+
+internal sealed class SeqConfigure : IConfigureNamedOptions<SeqOptions>, IValidateOptions<SeqOptions>
+{
+    private readonly IConfiguration _configuration;
+    private readonly IServiceProvider _serviceProvider;
+
+    public SeqConfigure(IConfiguration configuration, IServiceProvider serviceProvider)
+    {
+        _configuration = configuration;
+        _serviceProvider = serviceProvider;
+    }
+
+    public void Configure(string? name, SeqOptions options)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(name);
+        _configuration.Bind($"HealthChecks:Seq:{name}", options);
+    }
+
+    public void Configure(SeqOptions options) => Configure(Options.DefaultName, options);
+
+    public ValidateOptionsResult Validate(string? name, SeqOptions options)
+    {
+        if (string.IsNullOrWhiteSpace(name))
+        {
+            return Fail("The name cannot be null or whitespace.");
+        }
+
+        if (options is null)
+        {
+            return Fail("The options cannot be null.");
+        }
+
+        if (options.Timeout < Timeout.Infinite)
+        {
+            return Fail("The timeout value must be a positive number in milliseconds or -1 for an infinite timeout.");
+        }
+
+        return options.Mode switch
+        {
+            SeqClientCreationMode.ServiceProvider => ValidateCreationModeServiceProvider(options),
+            SeqClientCreationMode.ServerUrl => ValidateCreationModeServerUrl(options),
+            _ => Fail($"The mode `{options.Mode}` is not supported."),
+        };
+    }
+
+    private ValidateOptionsResult ValidateCreationModeServiceProvider(SeqOptions options)
+    {
+        var client = options.KeyedService is null
+            ? _serviceProvider.GetService<SeqConnection>()
+            : _serviceProvider.GetKeyedService<SeqConnection>(options.KeyedService);
+
+        if (client is null)
+        {
+            return Fail(
+                $"No service of type `{nameof(SeqConnection)}` registered. Please execute `services.AddSingleton(<client instance>)`."
+            );
+        }
+
+        return Success;
+    }
+
+    private static ValidateOptionsResult ValidateCreationModeServerUrl(SeqOptions options)
+    {
+        const string creationModeName = nameof(SeqClientCreationMode.ServerUrl);
+
+        if (options.ServerUrl is null)
+        {
+            return Fail($"The server url cannot be null when using the `{creationModeName}` client creation mode.");
+        }
+
+        if (!options.ServerUrl.IsAbsoluteUri)
+        {
+            return Fail(
+                $"The server url must be an absolute url when using the `{creationModeName}` client creation mode."
+            );
+        }
+
+        return Success;
+    }
+}

--- a/src/NetEvolve.HealthChecks.Seq/SeqHealthCheck.cs
+++ b/src/NetEvolve.HealthChecks.Seq/SeqHealthCheck.cs
@@ -1,0 +1,43 @@
+namespace NetEvolve.HealthChecks.Seq;
+
+using System.Threading;
+using System.Threading.Tasks;
+using global::Seq.Api;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using NetEvolve.Extensions.Tasks;
+using SourceGenerator.Attributes;
+
+[ConfigurableHealthCheck(typeof(SeqOptions))]
+internal sealed partial class SeqHealthCheck
+{
+    private async ValueTask<HealthCheckResult> ExecuteHealthCheckAsync(
+        string name,
+        HealthStatus failureStatus,
+        SeqOptions options,
+        CancellationToken cancellationToken
+    )
+    {
+        var clientProvider = _serviceProvider.GetRequiredService<SeqClientProvider>();
+        var client = clientProvider.GetClient(name, options, _serviceProvider);
+
+        var commandTask = options.CommandAsync.Invoke(client, cancellationToken);
+
+        var (isTimelyResponse, resultIsValid) = await commandTask
+            .WithTimeoutAsync(options.Timeout, cancellationToken)
+            .ConfigureAwait(false);
+
+        if (!resultIsValid)
+        {
+            return HealthCheckUnhealthy(failureStatus, name, "The command did not return a valid result.");
+        }
+
+        return HealthCheckState(isTimelyResponse, name);
+    }
+
+    internal static async Task<bool> DefaultCommandAsync(SeqConnection client, CancellationToken cancellationToken)
+    {
+        var root = await client.Client.GetRootAsync(cancellationToken).ConfigureAwait(false);
+        return root is not null;
+    }
+}

--- a/src/NetEvolve.HealthChecks.Seq/SeqOptions.cs
+++ b/src/NetEvolve.HealthChecks.Seq/SeqOptions.cs
@@ -1,0 +1,64 @@
+namespace NetEvolve.HealthChecks.Seq;
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using global::Seq.Api;
+
+/// <summary>
+/// Options for <see cref="SeqHealthCheck"/>
+/// </summary>
+public sealed record SeqOptions
+{
+    /// <summary>
+    /// Gets or sets the mode used to create a client instance.
+    /// </summary>
+    /// <remarks>
+    /// Defaults to <see cref="SeqClientCreationMode.ServiceProvider"/>.
+    /// </remarks>
+    public SeqClientCreationMode Mode { get; set; } = SeqClientCreationMode.ServiceProvider;
+
+    /// <summary>
+    /// Gets or sets the key used to resolve the <see cref="SeqConnection"/> from the service provider.
+    /// </summary>
+    /// <remarks>
+    /// When specified, the health check will resolve the <see cref="SeqConnection"/> using <c>IServiceProvider.GetRequiredKeyedService</c>.
+    /// <br/>
+    /// When <see langword="null"/> or <see langword="empty"/>, the health check will resolve the <see cref="SeqConnection"/> using <c>IServiceProvider.GetRequiredService</c>.
+    /// </remarks>
+    public string? KeyedService { get; set; }
+
+    /// <summary>
+    /// Gets or sets the base url of the Seq instance to check.
+    /// </summary>
+    /// <remarks>
+    /// This option is only required when <see cref="Mode"/> is set to <see cref="SeqClientCreationMode.ServerUrl"/>.
+    /// </remarks>
+    public Uri? ServerUrl { get; set; }
+
+    /// <summary>
+    /// Gets or sets the api key used to authenticate with the Seq instance.
+    /// </summary>
+    /// <remarks>
+    /// This option is optional and only used when <see cref="Mode"/> is set to <see cref="SeqClientCreationMode.ServerUrl"/>.
+    /// </remarks>
+    public string? ApiKey { get; set; }
+
+    /// <summary>
+    /// Gets or sets the timeout to use when connecting and executing tasks against the service.
+    /// </summary>
+    /// <remarks>
+    /// Defaults to <c>100 milliseconds</c>.
+    /// <br/>
+    /// Values below <see cref="Timeout.Infinite"/> (-1) are invalid.
+    /// </remarks>
+    public int Timeout { get; set; } = 100;
+
+    /// <summary>
+    /// Gets or sets the command to execute against the service.
+    /// Returns <see langword="true"/> if successful, <see langword="false"/> otherwise.
+    /// </summary>
+    /// <remarks>For internal use only.</remarks>
+    public Func<SeqConnection, CancellationToken, Task<bool>> CommandAsync { get; set; } =
+        SeqHealthCheck.DefaultCommandAsync;
+}

--- a/tests/NetEvolve.HealthChecks.Tests.Integration/NetEvolve.HealthChecks.Tests.Integration.csproj
+++ b/tests/NetEvolve.HealthChecks.Tests.Integration/NetEvolve.HealthChecks.Tests.Integration.csproj
@@ -131,6 +131,7 @@
     <PackageReference Include="Testcontainers.RavenDb" />
     <PackageReference Include="Testcontainers.Redis" />
     <PackageReference Include="Testcontainers.Redpanda" />
+    <PackageReference Include="Testcontainers.Seq" />
     <PackageReference Include="Testcontainers.ServiceBus" />
     <PackageReference Include="TUnit" />
     <PackageReference Include="Verify.TUnit" />
@@ -210,6 +211,7 @@
     <ProjectReference Include="..\..\src\NetEvolve.HealthChecks.RavenDb\NetEvolve.HealthChecks.RavenDb.csproj" />
     <ProjectReference Include="..\..\src\NetEvolve.HealthChecks.Redis\NetEvolve.HealthChecks.Redis.csproj" />
     <ProjectReference Include="..\..\src\NetEvolve.HealthChecks.Redpanda\NetEvolve.HealthChecks.Redpanda.csproj" />
+    <ProjectReference Include="..\..\src\NetEvolve.HealthChecks.Seq\NetEvolve.HealthChecks.Seq.csproj" />
     <ProjectReference Include="..\..\src\NetEvolve.HealthChecks.SQLite.Devart\NetEvolve.HealthChecks.SQLite.Devart.csproj" />
     <ProjectReference Include="..\..\src\NetEvolve.HealthChecks.SQLite.Legacy\NetEvolve.HealthChecks.SQLite.Legacy.csproj" />
     <ProjectReference Include="..\..\src\NetEvolve.HealthChecks.SQLite\NetEvolve.HealthChecks.SQLite.csproj" />

--- a/tests/NetEvolve.HealthChecks.Tests.Integration/Seq/.testgroup
+++ b/tests/NetEvolve.HealthChecks.Tests.Integration/Seq/.testgroup
@@ -1,0 +1,1 @@
+Z03TestGroup

--- a/tests/NetEvolve.HealthChecks.Tests.Integration/Seq/Container/SeqContainerAccess.cs
+++ b/tests/NetEvolve.HealthChecks.Tests.Integration/Seq/Container/SeqContainerAccess.cs
@@ -1,0 +1,22 @@
+namespace NetEvolve.HealthChecks.Tests.Integration.Seq.Container;
+
+using System;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging.Abstractions;
+using Testcontainers.Seq;
+
+public sealed class SeqContainerAccess : IAsyncInitializer, IAsyncDisposable
+{
+    private readonly SeqContainer _container = new SeqBuilder(
+        /*dockerimage*/"datalust/seq:2025.2"
+    )
+        .WithLogger(NullLogger.Instance)
+        .WithAcceptLicenseAgreement(true)
+        .Build();
+
+    public Uri ServerUrl => new Uri(_container.GetEndpoint());
+
+    public async ValueTask DisposeAsync() => await _container.DisposeAsync().ConfigureAwait(false);
+
+    public async Task InitializeAsync() => await _container.StartAsync().ConfigureAwait(false);
+}

--- a/tests/NetEvolve.HealthChecks.Tests.Integration/Seq/SeqHealthCheckTests.cs
+++ b/tests/NetEvolve.HealthChecks.Tests.Integration/Seq/SeqHealthCheckTests.cs
@@ -25,7 +25,7 @@ public sealed class SeqHealthCheckTests : HealthCheckTestBase
         await RunAndVerify(
             healthChecks => healthChecks.AddSeq("ServiceProviderHealthy", options => options.Timeout = 10000),
             HealthStatus.Healthy,
-            serviceBuilder: services => services.AddSingleton(new SeqConnection(_container.ServerUrl.ToString()))
+            serviceBuilder: services => services.AddSingleton(_ => new SeqConnection(_container.ServerUrl.ToString()))
         );
 
     [Test]
@@ -54,7 +54,7 @@ public sealed class SeqHealthCheckTests : HealthCheckTestBase
         await RunAndVerify(
             healthChecks => healthChecks.AddSeq("ServiceProviderDegraded", options => options.Timeout = 0),
             HealthStatus.Degraded,
-            serviceBuilder: services => services.AddSingleton(new SeqConnection(_container.ServerUrl.ToString()))
+            serviceBuilder: services => services.AddSingleton(_ => new SeqConnection(_container.ServerUrl.ToString()))
         );
 
     [Test]
@@ -97,7 +97,8 @@ public sealed class SeqHealthCheckTests : HealthCheckTestBase
                 await RunAndVerify(
                     healthChecks => healthChecks.AddSeq("DoubleRegistered").AddSeq("DoubleRegistered"),
                     HealthStatus.Healthy,
-                    serviceBuilder: services => services.AddSingleton(new SeqConnection(_container.ServerUrl.ToString()))
+                    serviceBuilder: services =>
+                        services.AddSingleton(_ => new SeqConnection(_container.ServerUrl.ToString()))
                 )
         );
 
@@ -115,7 +116,7 @@ public sealed class SeqHealthCheckTests : HealthCheckTestBase
                         }
                 ),
             HealthStatus.Unhealthy,
-            serviceBuilder: services => services.AddSingleton(new SeqConnection(_container.ServerUrl.ToString()))
+            serviceBuilder: services => services.AddSingleton(_ => new SeqConnection(_container.ServerUrl.ToString()))
         );
 
     [Test]
@@ -131,7 +132,7 @@ public sealed class SeqHealthCheckTests : HealthCheckTestBase
                 };
                 _ = config.AddInMemoryCollection(values);
             },
-            serviceBuilder: services => services.AddSingleton(new SeqConnection(_container.ServerUrl.ToString()))
+            serviceBuilder: services => services.AddSingleton(_ => new SeqConnection(_container.ServerUrl.ToString()))
         );
 
     [Test]
@@ -179,6 +180,6 @@ public sealed class SeqHealthCheckTests : HealthCheckTestBase
                 };
                 _ = config.AddInMemoryCollection(values);
             },
-            serviceBuilder: services => services.AddSingleton(new SeqConnection(_container.ServerUrl.ToString()))
+            serviceBuilder: services => services.AddSingleton(_ => new SeqConnection(_container.ServerUrl.ToString()))
         );
 }

--- a/tests/NetEvolve.HealthChecks.Tests.Integration/Seq/SeqHealthCheckTests.cs
+++ b/tests/NetEvolve.HealthChecks.Tests.Integration/Seq/SeqHealthCheckTests.cs
@@ -1,0 +1,184 @@
+namespace NetEvolve.HealthChecks.Tests.Integration.Seq;
+
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using global::Seq.Api;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using NetEvolve.Extensions.TUnit;
+using NetEvolve.HealthChecks.Seq;
+using NetEvolve.HealthChecks.Tests.Integration.Seq.Container;
+
+[TestGroup(nameof(Seq))]
+[TestGroup("Z03TestGroup")]
+[ClassDataSource<SeqContainerAccess>(Shared = SharedType.PerClass)]
+public sealed class SeqHealthCheckTests : HealthCheckTestBase
+{
+    private readonly SeqContainerAccess _container;
+
+    public SeqHealthCheckTests(SeqContainerAccess container) => _container = container;
+
+    [Test]
+    public async Task AddSeq_UseOptions_ModeServiceProvider_Healthy() =>
+        await RunAndVerify(
+            healthChecks => healthChecks.AddSeq("ServiceProviderHealthy", options => options.Timeout = 10000),
+            HealthStatus.Healthy,
+            serviceBuilder: services => services.AddSingleton(new SeqConnection(_container.ServerUrl.ToString()))
+        );
+
+    [Test]
+    public async Task AddSeq_UseOptions_WithKeyedService_Healthy()
+    {
+        const string serviceKey = "seq-test";
+
+        await RunAndVerify(
+            healthChecks =>
+                healthChecks.AddSeq(
+                    "KeyedServiceProviderHealthy",
+                    options =>
+                    {
+                        options.KeyedService = serviceKey;
+                        options.Timeout = 10000;
+                    }
+                ),
+            HealthStatus.Healthy,
+            serviceBuilder: services =>
+                services.AddKeyedSingleton(serviceKey, (_, _) => new SeqConnection(_container.ServerUrl.ToString()))
+        );
+    }
+
+    [Test]
+    public async Task AddSeq_UseOptions_ModeServiceProvider_Degraded() =>
+        await RunAndVerify(
+            healthChecks => healthChecks.AddSeq("ServiceProviderDegraded", options => options.Timeout = 0),
+            HealthStatus.Degraded,
+            serviceBuilder: services => services.AddSingleton(new SeqConnection(_container.ServerUrl.ToString()))
+        );
+
+    [Test]
+    public async Task AddSeq_UseOptions_ModeServerUrl_Healthy() =>
+        await RunAndVerify(
+            healthChecks =>
+                healthChecks.AddSeq(
+                    "ServerUrlHealthy",
+                    options =>
+                    {
+                        options.Mode = SeqClientCreationMode.ServerUrl;
+                        options.ServerUrl = _container.ServerUrl;
+                        options.Timeout = 10000;
+                    }
+                ),
+            HealthStatus.Healthy
+        );
+
+    [Test]
+    public async Task AddSeq_UseOptions_ModeServerUrl_Degraded() =>
+        await RunAndVerify(
+            healthChecks =>
+                healthChecks.AddSeq(
+                    "ServerUrlDegraded",
+                    options =>
+                    {
+                        options.Mode = SeqClientCreationMode.ServerUrl;
+                        options.ServerUrl = _container.ServerUrl;
+                        options.Timeout = 0;
+                    }
+                ),
+            HealthStatus.Degraded
+        );
+
+    [Test]
+    public async Task AddSeq_UseOptionsDoubleRegistered_ThrowsArgumentException() =>
+        await Assert.ThrowsAsync<ArgumentException>(
+            "name",
+            async () =>
+                await RunAndVerify(
+                    healthChecks => healthChecks.AddSeq("DoubleRegistered").AddSeq("DoubleRegistered"),
+                    HealthStatus.Healthy,
+                    serviceBuilder: services => services.AddSingleton(new SeqConnection(_container.ServerUrl.ToString()))
+                )
+        );
+
+    [Test]
+    public async Task AddSeq_UseOptions_Unhealthy() =>
+        await RunAndVerify(
+            healthChecks =>
+                healthChecks.AddSeq(
+                    "Unhealthy",
+                    options =>
+                        options.CommandAsync = async (_, _) =>
+                        {
+                            await Task.CompletedTask;
+                            throw new InvalidOperationException("Unhealthy test exception");
+                        }
+                ),
+            HealthStatus.Unhealthy,
+            serviceBuilder: services => services.AddSingleton(new SeqConnection(_container.ServerUrl.ToString()))
+        );
+
+    [Test]
+    public async Task AddSeq_UseConfiguration_ModeServiceProvider_Healthy() =>
+        await RunAndVerify(
+            healthChecks => healthChecks.AddSeq("ConfigServiceProviderHealthy"),
+            HealthStatus.Healthy,
+            config =>
+            {
+                var values = new Dictionary<string, string?>(StringComparer.Ordinal)
+                {
+                    { "HealthChecks:Seq:ConfigServiceProviderHealthy:Timeout", "10000" },
+                };
+                _ = config.AddInMemoryCollection(values);
+            },
+            serviceBuilder: services => services.AddSingleton(new SeqConnection(_container.ServerUrl.ToString()))
+        );
+
+    [Test]
+    public async Task AddSeq_UseConfiguration_ModeServerUrl_Healthy() =>
+        await RunAndVerify(
+            healthChecks => healthChecks.AddSeq("ConfigServerUrlHealthy"),
+            HealthStatus.Healthy,
+            config =>
+            {
+                var values = new Dictionary<string, string?>(StringComparer.Ordinal)
+                {
+                    { "HealthChecks:Seq:ConfigServerUrlHealthy:Mode", nameof(SeqClientCreationMode.ServerUrl) },
+                    { "HealthChecks:Seq:ConfigServerUrlHealthy:ServerUrl", _container.ServerUrl.ToString() },
+                    { "HealthChecks:Seq:ConfigServerUrlHealthy:Timeout", "10000" },
+                };
+                _ = config.AddInMemoryCollection(values);
+            }
+        );
+
+    [Test]
+    public async Task AddSeq_UseConfiguration_ModeServerUrl_ServerUrlMissing_Unhealthy() =>
+        await RunAndVerify(
+            healthChecks => healthChecks.AddSeq("ConfigServerUrlMissing"),
+            HealthStatus.Unhealthy,
+            config =>
+            {
+                var values = new Dictionary<string, string?>(StringComparer.Ordinal)
+                {
+                    { "HealthChecks:Seq:ConfigServerUrlMissing:Mode", nameof(SeqClientCreationMode.ServerUrl) },
+                };
+                _ = config.AddInMemoryCollection(values);
+            }
+        );
+
+    [Test]
+    public async Task AddSeq_UseConfiguration_TimeoutMinusTwo_Unhealthy() =>
+        await RunAndVerify(
+            healthChecks => healthChecks.AddSeq("ConfigTimeoutInvalid"),
+            HealthStatus.Unhealthy,
+            config =>
+            {
+                var values = new Dictionary<string, string?>(StringComparer.Ordinal)
+                {
+                    { "HealthChecks:Seq:ConfigTimeoutInvalid:Timeout", "-2" },
+                };
+                _ = config.AddInMemoryCollection(values);
+            },
+            serviceBuilder: services => services.AddSingleton(new SeqConnection(_container.ServerUrl.ToString()))
+        );
+}

--- a/tests/NetEvolve.HealthChecks.Tests.Integration/_snapshots/NetEvolve.HealthChecks.Seq.PublicApi_HasNotChanged_Theory.verified.txt
+++ b/tests/NetEvolve.HealthChecks.Tests.Integration/_snapshots/NetEvolve.HealthChecks.Seq.PublicApi_HasNotChanged_Theory.verified.txt
@@ -1,0 +1,22 @@
+﻿namespace NetEvolve.HealthChecks.Seq
+{
+    public static class DependencyInjectionExtensions
+    {
+        public static Microsoft.Extensions.DependencyInjection.IHealthChecksBuilder AddSeq([System.Diagnostics.CodeAnalysis.NotNull] this Microsoft.Extensions.DependencyInjection.IHealthChecksBuilder builder, [System.Diagnostics.CodeAnalysis.NotNull] string name, System.Action<NetEvolve.HealthChecks.Seq.SeqOptions>? options = null, params string[] tags) { }
+    }
+    public enum SeqClientCreationMode
+    {
+        ServiceProvider = 0,
+        ServerUrl = 1,
+    }
+    public sealed class SeqOptions : System.IEquatable<NetEvolve.HealthChecks.Seq.SeqOptions>
+    {
+        public SeqOptions() { }
+        public string? ApiKey { get; set; }
+        public System.Func<Seq.Api.SeqConnection, System.Threading.CancellationToken, System.Threading.Tasks.Task<bool>> CommandAsync { get; set; }
+        public string? KeyedService { get; set; }
+        public NetEvolve.HealthChecks.Seq.SeqClientCreationMode Mode { get; set; }
+        public System.Uri? ServerUrl { get; set; }
+        public int Timeout { get; set; }
+    }
+}

--- a/tests/NetEvolve.HealthChecks.Tests.Integration/_snapshots/SeqHealthCheck.AddSeq_UseConfiguration_ModeServerUrl_Healthy.verified.txt
+++ b/tests/NetEvolve.HealthChecks.Tests.Integration/_snapshots/SeqHealthCheck.AddSeq_UseConfiguration_ModeServerUrl_Healthy.verified.txt
@@ -1,0 +1,14 @@
+{
+  results: [
+    {
+      description: ConfigServerUrlHealthy: Healthy,
+      name: ConfigServerUrlHealthy,
+      status: Healthy,
+      tags: [
+        seq,
+        logging
+      ]
+    }
+  ],
+  status: Healthy
+}

--- a/tests/NetEvolve.HealthChecks.Tests.Integration/_snapshots/SeqHealthCheck.AddSeq_UseConfiguration_ModeServerUrl_ServerUrlMissing_Unhealthy.verified.txt
+++ b/tests/NetEvolve.HealthChecks.Tests.Integration/_snapshots/SeqHealthCheck.AddSeq_UseConfiguration_ModeServerUrl_ServerUrlMissing_Unhealthy.verified.txt
@@ -1,0 +1,18 @@
+{
+  results: [
+    {
+      description: ConfigServerUrlMissing: Unexpected error.,
+      exception: {
+        message: The server url cannot be null when using the `ServerUrl` client creation mode.,
+        type: Microsoft.Extensions.Options.OptionsValidationException
+      },
+      name: ConfigServerUrlMissing,
+      status: Unhealthy,
+      tags: [
+        seq,
+        logging
+      ]
+    }
+  ],
+  status: Unhealthy
+}

--- a/tests/NetEvolve.HealthChecks.Tests.Integration/_snapshots/SeqHealthCheck.AddSeq_UseConfiguration_ModeServiceProvider_Healthy.verified.txt
+++ b/tests/NetEvolve.HealthChecks.Tests.Integration/_snapshots/SeqHealthCheck.AddSeq_UseConfiguration_ModeServiceProvider_Healthy.verified.txt
@@ -1,0 +1,14 @@
+{
+  results: [
+    {
+      description: ConfigServiceProviderHealthy: Healthy,
+      name: ConfigServiceProviderHealthy,
+      status: Healthy,
+      tags: [
+        seq,
+        logging
+      ]
+    }
+  ],
+  status: Healthy
+}

--- a/tests/NetEvolve.HealthChecks.Tests.Integration/_snapshots/SeqHealthCheck.AddSeq_UseConfiguration_TimeoutMinusTwo_Unhealthy.verified.txt
+++ b/tests/NetEvolve.HealthChecks.Tests.Integration/_snapshots/SeqHealthCheck.AddSeq_UseConfiguration_TimeoutMinusTwo_Unhealthy.verified.txt
@@ -1,0 +1,18 @@
+{
+  results: [
+    {
+      description: ConfigTimeoutInvalid: Unexpected error.,
+      exception: {
+        message: The timeout value must be a positive number in milliseconds or -1 for an infinite timeout.,
+        type: Microsoft.Extensions.Options.OptionsValidationException
+      },
+      name: ConfigTimeoutInvalid,
+      status: Unhealthy,
+      tags: [
+        seq,
+        logging
+      ]
+    }
+  ],
+  status: Unhealthy
+}

--- a/tests/NetEvolve.HealthChecks.Tests.Integration/_snapshots/SeqHealthCheck.AddSeq_UseOptions_ModeServerUrl_Degraded.verified.txt
+++ b/tests/NetEvolve.HealthChecks.Tests.Integration/_snapshots/SeqHealthCheck.AddSeq_UseOptions_ModeServerUrl_Degraded.verified.txt
@@ -1,0 +1,14 @@
+{
+  results: [
+    {
+      description: ServerUrlDegraded: Degraded,
+      name: ServerUrlDegraded,
+      status: Degraded,
+      tags: [
+        seq,
+        logging
+      ]
+    }
+  ],
+  status: Degraded
+}

--- a/tests/NetEvolve.HealthChecks.Tests.Integration/_snapshots/SeqHealthCheck.AddSeq_UseOptions_ModeServerUrl_Healthy.verified.txt
+++ b/tests/NetEvolve.HealthChecks.Tests.Integration/_snapshots/SeqHealthCheck.AddSeq_UseOptions_ModeServerUrl_Healthy.verified.txt
@@ -1,0 +1,14 @@
+{
+  results: [
+    {
+      description: ServerUrlHealthy: Healthy,
+      name: ServerUrlHealthy,
+      status: Healthy,
+      tags: [
+        seq,
+        logging
+      ]
+    }
+  ],
+  status: Healthy
+}

--- a/tests/NetEvolve.HealthChecks.Tests.Integration/_snapshots/SeqHealthCheck.AddSeq_UseOptions_ModeServiceProvider_Degraded.verified.txt
+++ b/tests/NetEvolve.HealthChecks.Tests.Integration/_snapshots/SeqHealthCheck.AddSeq_UseOptions_ModeServiceProvider_Degraded.verified.txt
@@ -1,0 +1,14 @@
+{
+  results: [
+    {
+      description: ServiceProviderDegraded: Degraded,
+      name: ServiceProviderDegraded,
+      status: Degraded,
+      tags: [
+        seq,
+        logging
+      ]
+    }
+  ],
+  status: Degraded
+}

--- a/tests/NetEvolve.HealthChecks.Tests.Integration/_snapshots/SeqHealthCheck.AddSeq_UseOptions_ModeServiceProvider_Healthy.verified.txt
+++ b/tests/NetEvolve.HealthChecks.Tests.Integration/_snapshots/SeqHealthCheck.AddSeq_UseOptions_ModeServiceProvider_Healthy.verified.txt
@@ -1,0 +1,14 @@
+{
+  results: [
+    {
+      description: ServiceProviderHealthy: Healthy,
+      name: ServiceProviderHealthy,
+      status: Healthy,
+      tags: [
+        seq,
+        logging
+      ]
+    }
+  ],
+  status: Healthy
+}

--- a/tests/NetEvolve.HealthChecks.Tests.Integration/_snapshots/SeqHealthCheck.AddSeq_UseOptions_Unhealthy.verified.txt
+++ b/tests/NetEvolve.HealthChecks.Tests.Integration/_snapshots/SeqHealthCheck.AddSeq_UseOptions_Unhealthy.verified.txt
@@ -1,0 +1,18 @@
+{
+  results: [
+    {
+      description: Unhealthy: Unexpected error.,
+      exception: {
+        message: Unhealthy test exception,
+        type: System.InvalidOperationException
+      },
+      name: Unhealthy,
+      status: Unhealthy,
+      tags: [
+        seq,
+        logging
+      ]
+    }
+  ],
+  status: Unhealthy
+}

--- a/tests/NetEvolve.HealthChecks.Tests.Integration/_snapshots/SeqHealthCheck.AddSeq_UseOptions_WithKeyedService_Healthy.verified.txt
+++ b/tests/NetEvolve.HealthChecks.Tests.Integration/_snapshots/SeqHealthCheck.AddSeq_UseOptions_WithKeyedService_Healthy.verified.txt
@@ -1,0 +1,14 @@
+{
+  results: [
+    {
+      description: KeyedServiceProviderHealthy: Healthy,
+      name: KeyedServiceProviderHealthy,
+      status: Healthy,
+      tags: [
+        seq,
+        logging
+      ]
+    }
+  ],
+  status: Healthy
+}

--- a/tests/NetEvolve.HealthChecks.Tests.Unit/NetEvolve.HealthChecks.Tests.Unit.csproj
+++ b/tests/NetEvolve.HealthChecks.Tests.Unit/NetEvolve.HealthChecks.Tests.Unit.csproj
@@ -85,6 +85,7 @@
     <ProjectReference Include="..\..\src\NetEvolve.HealthChecks.RavenDb\NetEvolve.HealthChecks.RavenDb.csproj" />
     <ProjectReference Include="..\..\src\NetEvolve.HealthChecks.Redis\NetEvolve.HealthChecks.Redis.csproj" />
     <ProjectReference Include="..\..\src\NetEvolve.HealthChecks.Redpanda\NetEvolve.HealthChecks.Redpanda.csproj" />
+    <ProjectReference Include="..\..\src\NetEvolve.HealthChecks.Seq\NetEvolve.HealthChecks.Seq.csproj" />
     <ProjectReference Include="..\..\src\NetEvolve.HealthChecks.SQLite.Devart\NetEvolve.HealthChecks.SQLite.Devart.csproj" />
     <ProjectReference Include="..\..\src\NetEvolve.HealthChecks.SQLite.Legacy\NetEvolve.HealthChecks.SQLite.Legacy.csproj" />
     <ProjectReference Include="..\..\src\NetEvolve.HealthChecks.SQLite\NetEvolve.HealthChecks.SQLite.csproj" />

--- a/tests/NetEvolve.HealthChecks.Tests.Unit/Seq/DependencyInjectionExtensionsTests.cs
+++ b/tests/NetEvolve.HealthChecks.Tests.Unit/Seq/DependencyInjectionExtensionsTests.cs
@@ -1,0 +1,88 @@
+namespace NetEvolve.HealthChecks.Tests.Unit.Seq;
+
+using System;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using NetEvolve.Extensions.TUnit;
+using NetEvolve.HealthChecks.Seq;
+
+[TestGroup(nameof(Seq))]
+public class DependencyInjectionExtensionsTests
+{
+    [Test]
+    public void AddSeq_WhenArgumentBuilderNull_ThrowArgumentNullException()
+    {
+        // Arrange
+        var builder = default(IHealthChecksBuilder);
+
+        // Act
+        void Act() => builder.AddSeq("Test");
+
+        // Assert
+        _ = Assert.Throws<ArgumentNullException>("builder", Act);
+    }
+
+    [Test]
+    public void AddSeq_WhenArgumentNameNull_ThrowArgumentNullException()
+    {
+        // Arrange
+        var configuration = new ConfigurationBuilder().Build();
+        var services = new ServiceCollection();
+        var builder = services.AddSingleton<IConfiguration>(configuration).AddHealthChecks();
+        const string? name = default;
+
+        // Act
+        void Act() => builder.AddSeq(name!);
+
+        // Assert
+        _ = Assert.Throws<ArgumentNullException>("name", Act);
+    }
+
+    [Test]
+    public void AddSeq_WhenArgumentNameEmpty_ThrowArgumentException()
+    {
+        // Arrange
+        var configuration = new ConfigurationBuilder().Build();
+        var services = new ServiceCollection();
+        var builder = services.AddSingleton<IConfiguration>(configuration).AddHealthChecks();
+        var name = string.Empty;
+
+        // Act
+        void Act() => builder.AddSeq(name);
+
+        // Assert
+        _ = Assert.Throws<ArgumentException>("name", Act);
+    }
+
+    [Test]
+    public void AddSeq_WhenArgumentTagsNull_ThrowArgumentNullException()
+    {
+        // Arrange
+        var configuration = new ConfigurationBuilder().Build();
+        var services = new ServiceCollection();
+        var builder = services.AddSingleton<IConfiguration>(configuration).AddHealthChecks();
+        var tags = default(string[]);
+
+        // Act
+        void Act() => builder.AddSeq("Test", tags: tags);
+
+        // Assert
+        _ = Assert.Throws<ArgumentNullException>("tags", Act);
+    }
+
+    [Test]
+    public void AddSeq_WhenArgumentNameIsAlreadyUsed_ThrowArgumentException()
+    {
+        // Arrange
+        var configuration = new ConfigurationBuilder().Build();
+        var services = new ServiceCollection();
+        var builder = services.AddSingleton<IConfiguration>(configuration).AddHealthChecks();
+        const string? name = "Test";
+
+        // Act
+        void Act() => builder.AddSeq(name).AddSeq(name);
+
+        // Assert
+        _ = Assert.Throws<ArgumentException>(nameof(name), Act);
+    }
+}

--- a/tests/NetEvolve.HealthChecks.Tests.Unit/Seq/SeqClientProviderTests.cs
+++ b/tests/NetEvolve.HealthChecks.Tests.Unit/Seq/SeqClientProviderTests.cs
@@ -1,0 +1,30 @@
+namespace NetEvolve.HealthChecks.Tests.Unit.Seq;
+
+using System;
+using NetEvolve.Extensions.TUnit;
+using NetEvolve.HealthChecks.Seq;
+
+[TestGroup(nameof(Seq))]
+public sealed class SeqClientProviderTests
+{
+    [Test]
+    [MethodDataSource(nameof(InvalidArgumentsTestData))]
+    public void CreateClient_Theory_Expected(Type expectedException, SeqClientCreationMode mode, Uri? serverUrl)
+    {
+        var options = new SeqOptions { Mode = mode, ServerUrl = serverUrl };
+        _ = Assert.Throws(expectedException, () => SeqClientProvider.CreateClient(options));
+    }
+
+    public static IEnumerable<Func<(Type, SeqClientCreationMode, Uri?)>> InvalidArgumentsTestData()
+    {
+        yield return () =>
+            (typeof(ArgumentOutOfRangeException), (SeqClientCreationMode)(-1), new Uri("http://localhost:5341"));
+        yield return () =>
+            (
+                typeof(ArgumentOutOfRangeException),
+                SeqClientCreationMode.ServiceProvider,
+                new Uri("http://localhost:5341")
+            );
+        yield return () => (typeof(ArgumentNullException), SeqClientCreationMode.ServerUrl, null);
+    }
+}

--- a/tests/NetEvolve.HealthChecks.Tests.Unit/Seq/SeqConfigureTests.cs
+++ b/tests/NetEvolve.HealthChecks.Tests.Unit/Seq/SeqConfigureTests.cs
@@ -1,0 +1,111 @@
+namespace NetEvolve.HealthChecks.Tests.Unit.Seq;
+
+using System;
+using global::Seq.Api;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using NetEvolve.Extensions.TUnit;
+using NetEvolve.HealthChecks.Seq;
+
+[TestGroup(nameof(Seq))]
+public sealed class SeqConfigureTests
+{
+    [Test]
+    public void Configure_OnlyOptions_ThrowsArgumentException()
+    {
+        // Arrange
+        var services = new ServiceCollection();
+        var configure = new SeqConfigure(new ConfigurationBuilder().Build(), services.BuildServiceProvider());
+        var options = new NetEvolve.HealthChecks.Seq.SeqOptions();
+
+        // Act / Assert
+        _ = Assert.Throws<ArgumentException>("name", () => configure.Configure(options));
+    }
+
+    [Test]
+    [MethodDataSource(nameof(GetValidateTestCases))]
+    public async Task Validate_Theory_Expected(
+        bool expectedResult,
+        string? expectedMessage,
+        string? name,
+        NetEvolve.HealthChecks.Seq.SeqOptions options
+    )
+    {
+        // Arrange
+        var services = new ServiceCollection();
+        var configure = new SeqConfigure(new ConfigurationBuilder().Build(), services.BuildServiceProvider());
+
+        // Act
+        var result = configure.Validate(name, options);
+
+        // Assert
+        using (Assert.Multiple())
+        {
+            _ = await Assert.That(result.Succeeded).IsEqualTo(expectedResult);
+            _ = await Assert.That(result.FailureMessage).IsEqualTo(expectedMessage);
+        }
+    }
+
+    public static IEnumerable<
+        Func<(bool, string?, string?, NetEvolve.HealthChecks.Seq.SeqOptions)>
+    > GetValidateTestCases()
+    {
+        yield return () => (false, "The name cannot be null or whitespace.", null, null!);
+        yield return () => (false, "The name cannot be null or whitespace.", "\t", null!);
+        yield return () => (false, "The options cannot be null.", "name", null!);
+        yield return () =>
+            (
+                false,
+                "The timeout value must be a positive number in milliseconds or -1 for an infinite timeout.",
+                "name",
+                new NetEvolve.HealthChecks.Seq.SeqOptions { Timeout = -2 }
+            );
+        yield return () =>
+            (
+                false,
+                "The mode `-1` is not supported.",
+                "name",
+                new NetEvolve.HealthChecks.Seq.SeqOptions { Mode = (SeqClientCreationMode)(-1) }
+            );
+
+        // Mode: ServiceProvider
+        yield return () =>
+            (
+                false,
+                $"No service of type `{nameof(SeqConnection)}` registered. Please execute `services.AddSingleton(<client instance>)`.",
+                "name",
+                new NetEvolve.HealthChecks.Seq.SeqOptions { Mode = SeqClientCreationMode.ServiceProvider }
+            );
+
+        // Mode: ServerUrl
+        yield return () =>
+            (
+                false,
+                "The server url cannot be null when using the `ServerUrl` client creation mode.",
+                "name",
+                new NetEvolve.HealthChecks.Seq.SeqOptions { Mode = SeqClientCreationMode.ServerUrl }
+            );
+        yield return () =>
+            (
+                false,
+                "The server url must be an absolute url when using the `ServerUrl` client creation mode.",
+                "name",
+                new NetEvolve.HealthChecks.Seq.SeqOptions
+                {
+                    Mode = SeqClientCreationMode.ServerUrl,
+                    ServerUrl = new Uri("relative/path", UriKind.Relative),
+                }
+            );
+        yield return () =>
+            (
+                true,
+                null,
+                "name",
+                new NetEvolve.HealthChecks.Seq.SeqOptions
+                {
+                    Mode = SeqClientCreationMode.ServerUrl,
+                    ServerUrl = new Uri("http://localhost:5341"),
+                }
+            );
+    }
+}

--- a/tests/NetEvolve.HealthChecks.Tests.Unit/Seq/SeqHealthCheckTests.cs
+++ b/tests/NetEvolve.HealthChecks.Tests.Unit/Seq/SeqHealthCheckTests.cs
@@ -1,0 +1,219 @@
+namespace NetEvolve.HealthChecks.Tests.Unit.Seq;
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using global::Seq.Api;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Microsoft.Extensions.Options;
+using NetEvolve.Extensions.TUnit;
+using NetEvolve.HealthChecks.Seq;
+using TUnit.Mocks;
+
+[TestGroup(nameof(Seq))]
+public sealed class SeqHealthCheckTests
+{
+    private const string TestName = nameof(Seq);
+
+    [Test]
+    public async Task CheckHealthAsync_WhenContextNull_ThrowArgumentNullException()
+    {
+        // Arrange
+        var serviceProvider = IServiceProvider.Mock();
+        var optionsMonitor = IOptionsMonitor<NetEvolve.HealthChecks.Seq.SeqOptions>.Mock();
+        var check = new SeqHealthCheck(serviceProvider, optionsMonitor);
+
+        // Act
+        async Task Act() => _ = await check.CheckHealthAsync(null!, default);
+
+        // Assert
+        _ = await Assert.ThrowsAsync<ArgumentNullException>("context", Act);
+    }
+
+    [Test]
+    public async Task CheckHealthAsync_WhenCancellationTokenIsCancelled_ShouldReturnUnhealthy()
+    {
+        // Arrange
+
+        var serviceProvider = IServiceProvider.Mock();
+        var optionsMonitor = IOptionsMonitor<NetEvolve.HealthChecks.Seq.SeqOptions>.Mock();
+
+        var check = new SeqHealthCheck(serviceProvider, optionsMonitor);
+        var context = new HealthCheckContext
+        {
+            Registration = new HealthCheckRegistration(TestName, check, null, null),
+        };
+        var cancellationToken = new CancellationToken(true);
+
+        // Act
+        var result = await check.CheckHealthAsync(context, cancellationToken);
+
+        // Assert
+        using (Assert.Multiple())
+        {
+            _ = await Assert.That(result.Status).IsEqualTo(HealthStatus.Unhealthy);
+            _ = await Assert.That(result.Description).IsEqualTo($"{TestName}: Cancellation requested.");
+        }
+    }
+
+    [Test]
+    public async Task CheckHealthAsync_WhenOptionsAreNull_ShouldReturnUnhealthy()
+    {
+        // Arrange
+
+        var serviceProvider = IServiceProvider.Mock();
+        var optionsMonitor = IOptionsMonitor<NetEvolve.HealthChecks.Seq.SeqOptions>.Mock();
+
+        var check = new SeqHealthCheck(serviceProvider, optionsMonitor);
+        var context = new HealthCheckContext
+        {
+            Registration = new HealthCheckRegistration(TestName, check, null, null),
+        };
+
+        // Act
+        var result = await check.CheckHealthAsync(context);
+
+        // Assert
+        using (Assert.Multiple())
+        {
+            _ = await Assert.That(result.Status).IsEqualTo(HealthStatus.Unhealthy);
+            _ = await Assert.That(result.Description).IsEqualTo($"{TestName}: Missing configuration.");
+        }
+    }
+
+    [Test]
+    public async Task CheckHealthAsync_WithKeyedService_ShouldUseKeyedService()
+    {
+        // Arrange
+        const string serviceKey = "test-key";
+
+        var options = new NetEvolve.HealthChecks.Seq.SeqOptions
+        {
+            KeyedService = serviceKey,
+            Timeout = 100,
+            CommandAsync = async (_, _) =>
+            {
+                await Task.CompletedTask;
+                return true;
+            },
+        };
+
+        var optionsMonitor = IOptionsMonitor<NetEvolve.HealthChecks.Seq.SeqOptions>.Mock();
+        _ = optionsMonitor.Get(TestName).Returns(options);
+
+        // Setup connection mock that returns success
+        using var connection = new SeqConnection("http://localhost/test", "test");
+
+        var serviceProvider = new ServiceCollection()
+            .AddKeyedSingleton(serviceKey, connection)
+            .AddSingleton<SeqClientProvider>()
+            .BuildServiceProvider();
+
+        var healthCheck = new SeqHealthCheck(serviceProvider, optionsMonitor);
+        var context = new HealthCheckContext
+        {
+            Registration = new HealthCheckRegistration(TestName, healthCheck, HealthStatus.Unhealthy, null),
+        };
+
+        // Act
+        var result = await healthCheck.CheckHealthAsync(context, CancellationToken.None);
+
+        // Assert
+        using (Assert.Multiple())
+        {
+            _ = await Assert.That(result.Status).IsEqualTo(HealthStatus.Healthy);
+            _ = await Assert.That(result.Description).IsEqualTo($"{TestName}: Healthy");
+        }
+    }
+
+    [Test]
+    public async Task CheckHealthAsync_WithoutKeyedService_ShouldUseDefaultService()
+    {
+        // Arrange
+        var options = new NetEvolve.HealthChecks.Seq.SeqOptions
+        {
+            KeyedService = null,
+            Timeout = 1000,
+            CommandAsync = async (_, _) =>
+            {
+                await Task.CompletedTask;
+                return true;
+            },
+        };
+
+        var optionsMonitor = IOptionsMonitor<NetEvolve.HealthChecks.Seq.SeqOptions>.Mock();
+        _ = optionsMonitor.Get(TestName).Returns(options);
+
+        // Setup connection mock that returns success
+        using var connection = new SeqConnection("http://localhost/test", "test");
+
+        var serviceProvider = new ServiceCollection()
+            .AddSingleton(connection)
+            .AddSingleton<SeqClientProvider>()
+            .BuildServiceProvider();
+
+        var healthCheck = new SeqHealthCheck(serviceProvider, optionsMonitor);
+        var context = new HealthCheckContext
+        {
+            Registration = new HealthCheckRegistration(TestName, healthCheck, HealthStatus.Unhealthy, null),
+        };
+
+        // Act
+        var result = await healthCheck.CheckHealthAsync(context, CancellationToken.None);
+
+        // Assert
+        using (Assert.Multiple())
+        {
+            _ = await Assert.That(result.Status).IsEqualTo(HealthStatus.Healthy);
+            _ = await Assert.That(result.Description).IsEqualTo($"{TestName}: Healthy");
+        }
+    }
+
+    [Test]
+    public async Task CheckHealthAsync_WhenConnectionFails_ShouldReturnUnhealthy()
+    {
+        // Arrange
+
+        var options = new NetEvolve.HealthChecks.Seq.SeqOptions
+        {
+            KeyedService = null,
+            Timeout = 1000,
+            CommandAsync = async (_, cancellationToken) =>
+            {
+                await Task.Delay(0, cancellationToken);
+                throw new InvalidOperationException("Seq unhealthy test");
+            },
+        };
+
+        var optionsMonitor = IOptionsMonitor<NetEvolve.HealthChecks.Seq.SeqOptions>.Mock();
+        _ = optionsMonitor.Get(TestName).Returns(options);
+
+        // Setup connection mock that throws an exception
+        using var connection = new SeqConnection("http://localhost/test", "test");
+
+        var serviceProvider = new ServiceCollection()
+            .AddSingleton(connection)
+            .AddSingleton<SeqClientProvider>()
+            .BuildServiceProvider();
+
+        var healthCheck = new SeqHealthCheck(serviceProvider, optionsMonitor);
+        var context = new HealthCheckContext
+        {
+            Registration = new HealthCheckRegistration(TestName, healthCheck, HealthStatus.Unhealthy, null),
+        };
+
+        // Act
+        var result = await healthCheck.CheckHealthAsync(context, CancellationToken.None);
+
+        // Assert
+        using (Assert.Multiple())
+        {
+            _ = await Assert.That(result.Status).IsEqualTo(HealthStatus.Unhealthy);
+            _ = await Assert
+                .That(result.Description)
+                .Contains($"{TestName}: Unexpected error.", StringComparison.Ordinal);
+            _ = await Assert.That(result.Exception).IsNotNull();
+        }
+    }
+}

--- a/tests/NetEvolve.HealthChecks.Tests.Unit/Seq/SeqOptionsTests.cs
+++ b/tests/NetEvolve.HealthChecks.Tests.Unit/Seq/SeqOptionsTests.cs
@@ -1,0 +1,18 @@
+namespace NetEvolve.HealthChecks.Tests.Unit.Seq;
+
+using System.Threading.Tasks;
+using NetEvolve.Extensions.TUnit;
+using NetEvolve.HealthChecks.Seq;
+
+[TestGroup(nameof(Seq))]
+public sealed class SeqOptionsTests
+{
+    [Test]
+    public async Task Options_NotSame_Expected()
+    {
+        var options1 = new SeqOptions();
+        var options2 = options1 with { };
+
+        _ = await Assert.That(options1).IsEqualTo(options2).And.IsNotSameReferenceAs(options2);
+    }
+}


### PR DESCRIPTION
## Summary
- Adds `AddSeq` health check backed by [`Seq.Api`](https://www.nuget.org/packages/Seq.Api/), following the existing `ServiceProvider` / direct-connection client pattern used by other integrations (e.g. Keycloak).
- Two client creation modes: `ServiceProvider` (resolve a preregistered `SeqConnection`) and `ServerUrl` (create one from `ServerUrl` + optional `ApiKey`).
- Default liveness command calls `SeqConnection.Client.GetRootAsync`.

Closes #2081

## Test plan
- [x] Unit tests (25) covering DI extension guards, client creation modes, options validation, health check behavior — all passing.
- [x] Integration tests added using `Testcontainers.Seq`, following the repo's `RunAndVerify` + Verify-snapshot pattern.
- [x] `PublicApiTests` snapshot added for the new assembly.
- [x] `dotnet build` clean (0 warnings/0 errors) for src, Unit, Integration, and Architecture test projects.
- [ ] Integration tests requiring Docker were not executed in this environment (no Docker available); expected to run in CI.