### PR TITLE
fix(tests): add missing projects to architecture test coverage

### DIFF
--- a/tests/NetEvolve.HealthChecks.Tests.Architecture/HealthCheckArchitecture.cs
+++ b/tests/NetEvolve.HealthChecks.Tests.Architecture/HealthCheckArchitecture.cs
@@ -23,6 +23,7 @@ internal static class HealthCheckArchitecture
             typeof(Apache.ActiveMq.ActiveMqHealthCheck).Assembly,
             typeof(Apache.Kafka.KafkaHealthCheck).Assembly,
             typeof(Apache.Pulsar.PulsarHealthCheck).Assembly,
+            typeof(Apache.RocketMQ.RocketMQHealthCheck).Assembly,
             typeof(Apache.Solr.SolrHealthCheck).Assembly,
             // AWS
             typeof(AWS.CloudWatch.CloudWatchHealthCheck).Assembly,
@@ -93,6 +94,7 @@ internal static class HealthCheckArchitecture
             typeof(Redpanda.RedpandaHealthCheck).Assembly,
             typeof(Qdrant.QdrantHealthCheck).Assembly,
             typeof(QuestDB.QuestDBHealthCheck).Assembly,
+            typeof(Seq.SeqHealthCheck).Assembly,
             typeof(SQLite.SQLiteHealthCheck).Assembly,
             typeof(SQLite.Devart.SQLiteDevartHealthCheck).Assembly,
             typeof(SQLite.Legacy.SQLiteLegacyHealthCheck).Assembly,

--- a/tests/NetEvolve.HealthChecks.Tests.Architecture/NetEvolve.HealthChecks.Tests.Architecture.csproj
+++ b/tests/NetEvolve.HealthChecks.Tests.Architecture/NetEvolve.HealthChecks.Tests.Architecture.csproj
@@ -12,6 +12,7 @@
   <ItemGroup>
     <ProjectReference Include="..\..\src\NetEvolve.HealthChecks.Apache.ActiveMq\NetEvolve.HealthChecks.Apache.ActiveMq.csproj" />
     <ProjectReference Include="..\..\src\NetEvolve.HealthChecks.Apache.Kafka\NetEvolve.HealthChecks.Apache.Kafka.csproj" />
+    <ProjectReference Include="..\..\src\NetEvolve.HealthChecks.Apache.RocketMQ\NetEvolve.HealthChecks.Apache.RocketMQ.csproj" />
     <ProjectReference Include="..\..\src\NetEvolve.HealthChecks.Apache.Solr\NetEvolve.HealthChecks.Apache.Solr.csproj" />
     <ProjectReference Include="..\..\src\NetEvolve.HealthChecks.ArangoDb\NetEvolve.HealthChecks.ArangoDb.csproj" />
     <ProjectReference Include="..\..\src\NetEvolve.HealthChecks.AWS.CloudWatch\NetEvolve.HealthChecks.AWS.CloudWatch.csproj" />
@@ -79,6 +80,7 @@
     <ProjectReference Include="..\..\src\NetEvolve.HealthChecks.RavenDb\NetEvolve.HealthChecks.RavenDb.csproj" />
     <ProjectReference Include="..\..\src\NetEvolve.HealthChecks.Redis\NetEvolve.HealthChecks.Redis.csproj" />
     <ProjectReference Include="..\..\src\NetEvolve.HealthChecks.Redpanda\NetEvolve.HealthChecks.Redpanda.csproj" />
+    <ProjectReference Include="..\..\src\NetEvolve.HealthChecks.Seq\NetEvolve.HealthChecks.Seq.csproj" />
     <ProjectReference Include="..\..\src\NetEvolve.HealthChecks.SQLite.Devart\NetEvolve.HealthChecks.SQLite.Devart.csproj" />
     <ProjectReference Include="..\..\src\NetEvolve.HealthChecks.SQLite.Legacy\NetEvolve.HealthChecks.SQLite.Legacy.csproj" />
     <ProjectReference Include="..\..\src\NetEvolve.HealthChecks.SQLite\NetEvolve.HealthChecks.SQLite.csproj" />


### PR DESCRIPTION
## Summary
- Add Apache.RocketMQ and Seq health check assemblies to the architecture test's assembly scan list
- Add corresponding ProjectReference entries so both projects are covered by architecture tests

## Test plan
- [x] dotnet build succeeds for the architecture test project